### PR TITLE
Fix IMF integration and TDE plotting

### DIFF
--- a/rapster/cluster_evolution.py
+++ b/rapster/cluster_evolution.py
@@ -80,8 +80,8 @@ def initialize_cluster(config):
     n_star0 = n_star
 
     # average stellar mass:
-    Kroupa_norm = 1 / integrate.quad(lambda x: IMF_kroupa(np.array([x])), m_min, m_max)[0]
-    m_avg = Kroupa_norm * integrate.quad(lambda x: x * IMF_kroupa(np.array([x])), m_min, m_max)[0]
+    Kroupa_norm = 1 / integrate.quad(IMF_kroupa, m_min, m_max)[0]
+    m_avg = Kroupa_norm * integrate.quad(lambda x: x * IMF_kroupa(x), m_min, m_max)[0]
 
     # initial average stellar mass:
     m_avg0 = m_avg
@@ -94,8 +94,8 @@ def initialize_cluster(config):
     R_gal0 = R_gal
 
     # initial multimass relaxation factor:
-    psi0 = integrate.quad(lambda x: x**(5/2) * IMF_kroupa(np.array([x])), m_min, m_max)[0] \
-        / integrate.quad(lambda x: IMF_kroupa(np.array([x])), m_min, m_max)[0] / m_avg**(5/2)
+    psi0 = integrate.quad(lambda x: x**(5/2) * IMF_kroupa(x), m_min, m_max)[0] \
+        / integrate.quad(IMF_kroupa, m_min, m_max)[0] / m_avg**(5/2)
 
     # initial relaxation timescale:
     t_rlx0 = t_relax(Mcl0, rh0, m_avg, psi0, np.log(lc * N))
@@ -130,8 +130,8 @@ def initialize_cluster(config):
         v_star = np.sqrt(0.4 * G_Newton * Mcl / rh)
 
     # number of massive stars:
-    N_massive = int(Mcl * integrate.quad(lambda x: IMF_kroupa(np.array([x])), mM_min, m_max)[0] \
-                    / integrate.quad(lambda x: x * IMF_kroupa(np.array([x])), m_min, m_max)[0])
+    N_massive = int(Mcl * integrate.quad(IMF_kroupa, mM_min, m_max)[0] \
+                    / integrate.quad(lambda x: x * IMF_kroupa(x), m_min, m_max)[0])
 
     if BMD==0:
         # default: Kroupa IMF + stellar collapse + SN kicks
@@ -227,7 +227,7 @@ def initialize_cluster(config):
 
     # optionally form and retain neutron stars based on natal kicks:
     if with_NSs==1:
-        f_NS_form = Kroupa_norm*integrate.quad(lambda m: IMF_kroupa(np.array([m])), 8, 18)[0]
+        f_NS_form = Kroupa_norm*integrate.quad(IMF_kroupa, 8, 18)[0]
         N_NS_form = int(f_NS_form*N)
         v_NS_natal = maxwell.rvs(loc=0, scale=np.sqrt(3)*wSN_kick, size=N_NS_form)
         N_NS_ret = v_NS_natal[v_NS_natal < v_esc(Mcl, rh)].size

--- a/rapster/plot_cluster.py
+++ b/rapster/plot_cluster.py
@@ -226,17 +226,25 @@ def plot_merger_channels(data, save_dir):
 
 
 def plot_tdes(data, save_dir):
-    """Plot TDE BH mass vs penetration factor and fallback time."""
+    """Plot TDE BH mass vs penetration factor and available time column."""
     tdes = data['tdes']
     if tdes is None or len(tdes) == 0:
         return
 
+    if 't_fb' in tdes:
+        y_values = tdes['t_fb'] * MYR_TO_SEC / 60
+        y_label = 'Fallback time (min)'
+    else:
+        y_values = tdes['t']
+        y_label = 'Cluster time (Myr)'
+
     fig, ax = plt.subplots(figsize=(8, 5))
-    sc = ax.scatter(tdes['beta'], tdes['t_fb'] * MYR_TO_SEC / 60, c=tdes['m_BH'], cmap='gnuplot')
+    sc = ax.scatter(tdes['beta'], y_values, c=tdes['m_BH'], cmap='gnuplot')
     plt.colorbar(sc, ax=ax, label=r'Black-hole mass ($M_\odot$)')
-    ax.set_yscale('log')
+    if np.all(y_values > 0):
+        ax.set_yscale('log')
     ax.set_xlabel(r'Penetration factor ($r_t/r_p$)')
-    ax.set_ylabel('Fallback time (min)')
+    ax.set_ylabel(y_label)
     ax.set_title('Tidal disruption events')
     fig.tight_layout()
     fig.savefig(os.path.join(save_dir, 'tdes.png'), dpi=150)

--- a/rapster/stellar_evolution.py
+++ b/rapster/stellar_evolution.py
@@ -23,10 +23,14 @@ def IMF_kroupa(m):
     """
     Kroupa (2002) initial mass function.
 
-    @in m : stellar mass array [Msun]
+    @in m : stellar mass or stellar mass array [Msun]
 
     @out: number dN of stars in mass bin (m,m+dm) [1/Msun]
     """
+
+    m = np.asarray(m, dtype=float)
+    scalar_input = (m.ndim == 0)
+    m = np.atleast_1d(m)
 
     # mass boundaries (in solar masses):
     m1 = 0.08
@@ -64,7 +68,7 @@ def IMF_kroupa(m):
             
             out[i] = c3 * m[i]**a3
                     
-    return out
+    return float(out[0]) if scalar_input else out
 
 N_grid = 700
 M_grid = np.linspace(10, 340, N_grid)


### PR DESCRIPTION
Fixes two runtime failures in:

  `python -m rapster.run_cluster -analyze 1 -plot 1`

  Changes:
  - Allow `IMF_kroupa` to accept scalar input while preserving array input behavior.
  - Use `integrate.quad(IMF_kroupa, ...)` directly for scalar SciPy integration.
  - Make TDE plotting compatible with the current `tdes.txt` schema when `t_fb` is
  absent.

  Verified with:

`python -m rapster.run_cluster -analyze 1 -plot 1`