### PR TITLE
v2.9.6: Bug fixes for extreme cluster parameter regimes

### DIFF
--- a/Example/Results_Test/log.txt
+++ b/Example/Results_Test/log.txt
@@ -1,5 +1,5 @@
 INITIALIZING...
-END OF INITIALIZATION. RUNTIME: 0.385 s
+END OF INITIALIZATION. RUNTIME: 0.376 s
 
 
 SIMULATING...
@@ -12,7 +12,7 @@ Iteration # 1
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.5      0.001
+           0.4      0.000
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -22,7 +22,7 @@ Iteration # 2
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.010
+           0.3      0.012
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -32,7 +32,7 @@ Iteration # 3
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.017
+           0.3      0.019
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -42,7 +42,7 @@ Iteration # 4
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.023
+           0.3      0.025
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -52,7 +52,7 @@ Iteration # 5
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.030
+           0.3      0.032
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -62,7 +62,7 @@ Iteration # 6
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.036
+           0.3      0.038
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -72,7 +72,7 @@ Iteration # 7
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.042
+           0.3      0.044
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -82,7 +82,7 @@ Iteration # 8
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.049
+           0.3      0.051
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -92,7 +92,7 @@ Iteration # 9
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.055
+           0.3      0.057
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -102,7 +102,7 @@ Iteration # 10
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.061
+           0.2      0.063
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -112,7 +112,7 @@ Iteration # 11
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.068
+           0.2      0.069
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -122,7 +122,7 @@ Iteration # 12
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.074
+           0.3      0.076
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -132,7 +132,7 @@ Iteration # 13
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.080
+           0.3      0.082
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -142,7 +142,7 @@ Iteration # 14
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.087
+           0.3      0.088
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -152,7 +152,7 @@ Iteration # 15
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.093
+           0.3      0.094
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -162,7 +162,7 @@ Iteration # 16
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.099
+           0.2      0.101
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -172,7 +172,7 @@ Iteration # 17
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.105
+           0.3      0.107
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -182,7 +182,7 @@ Iteration # 18
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.112
+           0.3      0.113
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -192,7 +192,7 @@ Iteration # 19
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.118
+           0.3      0.120
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -202,7 +202,7 @@ Iteration # 20
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.124
+           0.2      0.126
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -212,7 +212,7 @@ Iteration # 21
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.131
+           0.3      0.132
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -222,7 +222,7 @@ Iteration # 22
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.137
+           0.3      0.138
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -232,7 +232,7 @@ Iteration # 23
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.143
+           0.3      0.144
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -242,7 +242,7 @@ Iteration # 24
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.149
+           0.3      0.151
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -252,7 +252,7 @@ Iteration # 25
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.156
+           0.3      0.157
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -262,7 +262,7 @@ Iteration # 26
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.162
+           0.3      0.163
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -272,7 +272,7 @@ Iteration # 27
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.168
+           0.2      0.169
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -282,7 +282,7 @@ Iteration # 28
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.174
+           0.3      0.175
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -292,7 +292,7 @@ Iteration # 29
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.180
+           0.3      0.181
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -302,7 +302,7 @@ Iteration # 30
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.187
+           0.3      0.188
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -312,7 +312,7 @@ Iteration # 31
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.193
+           0.3      0.194
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -322,7 +322,7 @@ Iteration # 32
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.199
+           0.3      0.200
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -332,7 +332,7 @@ Iteration # 33
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.205
+           0.2      0.206
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -342,7 +342,7 @@ Iteration # 34
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.211
+           0.3      0.213
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -352,7 +352,7 @@ Iteration # 35
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
      0     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.2      0.218
+           0.2      0.219
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -362,7 +362,7 @@ Iteration # 36
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.4      0.224
+           0.4      0.225
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -372,7 +372,7 @@ Iteration # 37
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.230
+           0.4      0.231
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -382,7 +382,7 @@ Iteration # 38
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.4      0.237
+           0.4      0.238
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -392,7 +392,7 @@ Iteration # 39
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.4      0.243
+           0.4      0.244
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -402,7 +402,7 @@ Iteration # 40
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.249
+           0.3      0.250
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -412,7 +412,7 @@ Iteration # 41
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.255
+           0.3      0.256
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -422,7 +422,7 @@ Iteration # 42
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.4      0.262
+           0.4      0.263
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -432,7 +432,7 @@ Iteration # 43
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.268
+           0.3      0.269
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -442,7 +442,7 @@ Iteration # 44
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.274
+           0.3      0.275
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -452,7 +452,7 @@ Iteration # 45
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.280
+           0.4      0.281
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -462,7 +462,7 @@ Iteration # 46
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.4      0.286
+           0.3      0.287
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -472,7 +472,7 @@ Iteration # 47
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.293
+           0.3      0.294
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -482,7 +482,7 @@ Iteration # 48
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.4      0.299
+           0.4      0.300
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -492,7 +492,7 @@ Iteration # 49
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.305
+           0.3      0.306
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -502,7 +502,7 @@ Iteration # 50
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.312
+           0.4      0.312
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -512,7 +512,7 @@ Iteration # 51
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.318
+           0.3      0.319
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -522,7 +522,7 @@ Iteration # 52
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.324
+           0.3      0.325
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -532,7 +532,7 @@ Iteration # 53
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.330
+           0.4      0.331
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -552,7 +552,7 @@ Iteration # 55
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1044     0         0    0         0           0
   steptime[ms] runtime[s]
-           0.3      0.343
+           0.4      0.343
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -562,7 +562,7 @@ Iteration # 56
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1039     1         0    0         0           0
   steptime[ms] runtime[s]
-           5.5      0.354
+           6.2      0.356
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -572,7 +572,7 @@ Iteration # 57
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1034     0         0    1         0           2
   steptime[ms] runtime[s]
-          21.5      0.382
+          21.2      0.383
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -582,7 +582,7 @@ Iteration # 58
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1024     1         0    2         0           2
   steptime[ms] runtime[s]
-          10.3      0.399
+          10.1      0.399
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -592,7 +592,7 @@ Iteration # 59
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1022     2         0    2         0           5
   steptime[ms] runtime[s]
-          14.7      0.419
+          14.7      0.420
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -602,7 +602,7 @@ Iteration # 60
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1010     1         0    3         0           6
   steptime[ms] runtime[s]
-           7.2      0.433
+           7.3      0.434
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -612,7 +612,7 @@ Iteration # 61
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1000     0         0    4         0           8
   steptime[ms] runtime[s]
-          13.4      0.452
+          13.4      0.453
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -622,7 +622,7 @@ Iteration # 62
    N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    1000     0         0    4         0           8
   steptime[ms] runtime[s]
-           0.8      0.459
+           0.9      0.460
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -632,7 +632,7 @@ Iteration # 63
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    999     1         0    4         0           8
   steptime[ms] runtime[s]
-           3.4      0.468
+           3.5      0.470
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -642,7 +642,7 @@ Iteration # 64
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    991     2         0    4         0          10
   steptime[ms] runtime[s]
-          10.3      0.485
+          10.2      0.486
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -652,7 +652,7 @@ Iteration # 65
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    991     2         0    4         0          11
   steptime[ms] runtime[s]
-           9.1      0.500
+           9.2      0.502
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -662,7 +662,7 @@ Iteration # 66
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    991     2         0    4         0          11
   steptime[ms] runtime[s]
-           0.9      0.507
+           0.9      0.509
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -672,7 +672,7 @@ Iteration # 67
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    990     2         0    4         0          12
   steptime[ms] runtime[s]
-           4.3      0.517
+           4.4      0.519
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -682,7 +682,7 @@ Iteration # 68
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    984     2         0    4         0          13
   steptime[ms] runtime[s]
-           5.8      0.529
+           5.9      0.531
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -692,7 +692,7 @@ Iteration # 69
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    984     2         0    4         0          13
   steptime[ms] runtime[s]
-           1.0      0.536
+           1.0      0.538
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -702,7 +702,7 @@ Iteration # 70
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    969     0         0    7         0          14
   steptime[ms] runtime[s]
-        4676.0      5.219
+        4657.8      5.202
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -712,7 +712,7 @@ Iteration # 71
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    968     1         0    7         0          14
   steptime[ms] runtime[s]
-           4.5      5.230
+           4.4      5.213
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -722,7 +722,7 @@ Iteration # 72
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    964     1         0    7         0          16
   steptime[ms] runtime[s]
-           8.2      5.244
+           7.9      5.227
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -732,7 +732,7 @@ Iteration # 73
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    960     3         0    7         0          16
   steptime[ms] runtime[s]
-          11.5      5.262
+          11.4      5.244
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -742,7 +742,7 @@ Iteration # 74
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    960     2         0    7         0          16
   steptime[ms] runtime[s]
-           1.4      5.277
+           1.1      5.252
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -752,7 +752,7 @@ Iteration # 75
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    947     1         0    8         0          16
   steptime[ms] runtime[s]
-           7.6      5.295
+           3.4      5.261
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -762,7 +762,7 @@ Iteration # 76
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    947     1         0    8         0          16
   steptime[ms] runtime[s]
-           1.2      5.325
+           0.8      5.268
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -772,7 +772,7 @@ Iteration # 77
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    947     2         0    8         0          18
   steptime[ms] runtime[s]
-          12.9      5.355
+          10.1      5.284
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -782,7 +782,7 @@ Iteration # 78
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    944     4         0    8         0          20
   steptime[ms] runtime[s]
-          15.7      5.377
+          15.2      5.305
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -792,7 +792,7 @@ Iteration # 79
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    938     2         0    8         0          20
   steptime[ms] runtime[s]
-           4.9      5.391
+           3.3      5.315
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -802,7 +802,7 @@ Iteration # 80
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    938     2         0    8         0          20
   steptime[ms] runtime[s]
-           1.2      5.402
+           1.0      5.322
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -812,7 +812,7 @@ Iteration # 81
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    937     2         0    8         0          21
   steptime[ms] runtime[s]
-          12.5      5.423
+           8.3      5.336
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -822,7 +822,7 @@ Iteration # 82
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    928     1         0    9         0          21
   steptime[ms] runtime[s]
-           2.3      5.433
+           2.1      5.344
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -832,7 +832,7 @@ Iteration # 83
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    921     1         0   10         0          22
   steptime[ms] runtime[s]
-          26.4      5.505
+           7.0      5.357
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -842,7 +842,7 @@ Iteration # 84
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    917     2         0   10         0          22
   steptime[ms] runtime[s]
-           8.2      5.521
+           5.2      5.368
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -852,7 +852,7 @@ Iteration # 85
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    910     3         0   11         0          22
   steptime[ms] runtime[s]
-           8.4      5.545
+           7.0      5.381
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -862,7 +862,7 @@ Iteration # 86
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    909     3         0   11         0          22
   steptime[ms] runtime[s]
-           6.0      5.559
+           5.5      5.393
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -872,7 +872,7 @@ Iteration # 87
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    909     3         0   11         0          22
   steptime[ms] runtime[s]
-           1.2      5.568
+           1.1      5.400
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -882,7 +882,7 @@ Iteration # 88
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    908     2         0   12         0          22
   steptime[ms] runtime[s]
-        8554.7     14.130
+        8408.8     13.815
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -892,7 +892,7 @@ Iteration # 89
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    908     2         0   12         0          22
   steptime[ms] runtime[s]
-           1.3     14.138
+           1.3     13.823
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -902,7 +902,7 @@ Iteration # 90
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    901     2         0   12         0          23
   steptime[ms] runtime[s]
-           7.6     14.151
+           7.6     13.836
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -912,7 +912,7 @@ Iteration # 91
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    901     2         0   12         0          23
   steptime[ms] runtime[s]
-           1.1     14.158
+           1.1     13.843
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -922,7 +922,7 @@ Iteration # 92
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    895     2         0   12         0          24
   steptime[ms] runtime[s]
-           7.4     14.172
+           7.2     13.856
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -932,7 +932,7 @@ Iteration # 93
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    888     2         0   12         0          26
   steptime[ms] runtime[s]
-          11.2     14.189
+          11.4     13.874
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -942,7 +942,7 @@ Iteration # 94
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    884     1         0   12         0          26
   steptime[ms] runtime[s]
-           4.1     14.199
+           4.2     13.884
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -952,7 +952,7 @@ Iteration # 95
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    883     2         0   12         0          27
   steptime[ms] runtime[s]
-           5.6     14.211
+           5.5     13.895
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -962,7 +962,7 @@ Iteration # 96
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    883     2         0   12         0          27
   steptime[ms] runtime[s]
-           0.9     14.218
+           1.0     13.902
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -972,7 +972,7 @@ Iteration # 97
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    878     1         0   12         0          28
   steptime[ms] runtime[s]
-           8.1     14.232
+           8.3     13.917
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -982,7 +982,7 @@ Iteration # 98
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    878     1         0   12         0          28
   steptime[ms] runtime[s]
-           0.8     14.239
+           0.8     13.923
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -992,7 +992,7 @@ Iteration # 99
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    873     1         0   12         0          29
   steptime[ms] runtime[s]
-           7.0     14.252
+           7.0     13.936
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1002,7 +1002,7 @@ Iteration # 100
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    870     0         0   12         0          31
   steptime[ms] runtime[s]
-           7.3     14.265
+           7.5     13.950
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1012,7 +1012,7 @@ Iteration # 101
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    863     1         0   12         0          31
   steptime[ms] runtime[s]
-           5.5     14.277
+           5.4     13.961
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1022,7 +1022,7 @@ Iteration # 102
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    860     0         0   13         0          31
   steptime[ms] runtime[s]
-           1.2     14.284
+           1.1     13.968
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1032,7 +1032,7 @@ Iteration # 103
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    860     0         0   13         0          32
   steptime[ms] runtime[s]
-           3.8     14.294
+           3.9     13.978
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1042,7 +1042,7 @@ Iteration # 104
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    855     1         0   13         0          33
   steptime[ms] runtime[s]
-           8.7     14.309
+           8.8     13.993
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1052,7 +1052,7 @@ Iteration # 105
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    855     1         0   13         0          33
   steptime[ms] runtime[s]
-           2.3     14.317
+           2.2     14.001
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1062,7 +1062,7 @@ Iteration # 106
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    845     2         0   13         0          33
   steptime[ms] runtime[s]
-           5.9     14.329
+           5.9     14.013
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1072,7 +1072,7 @@ Iteration # 107
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    845     3         0   13         0          33
   steptime[ms] runtime[s]
-           7.5     14.367
+           7.5     14.046
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1082,7 +1082,7 @@ Iteration # 108
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    840     2         0   13         0          33
   steptime[ms] runtime[s]
-           3.7     14.377
+           3.8     14.056
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1092,7 +1092,7 @@ Iteration # 109
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    836     1         0   13         0          33
   steptime[ms] runtime[s]
-           2.5     14.385
+           2.6     14.065
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1102,7 +1102,7 @@ Iteration # 110
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    836     1         0   13         0          34
   steptime[ms] runtime[s]
-           6.6     14.398
+           6.6     14.077
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1112,7 +1112,7 @@ Iteration # 111
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    836     1         0   13         0          34
   steptime[ms] runtime[s]
-           0.9     14.405
+           0.8     14.084
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1122,7 +1122,7 @@ Iteration # 112
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    830     0         0   13         0          34
   steptime[ms] runtime[s]
-           1.4     14.412
+           1.4     14.091
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1132,7 +1132,7 @@ Iteration # 113
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    830     1         0   13         0          34
   steptime[ms] runtime[s]
-           2.6     14.421
+           2.7     14.100
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1142,7 +1142,7 @@ Iteration # 114
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    828     2         0   13         0          34
   steptime[ms] runtime[s]
-           6.6     14.433
+           6.7     14.113
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1152,7 +1152,7 @@ Iteration # 115
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    828     3         0   13         0          34
   steptime[ms] runtime[s]
-           5.6     14.445
+           5.5     14.124
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1162,7 +1162,7 @@ Iteration # 116
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    828     3         0   13         0          34
   steptime[ms] runtime[s]
-           1.0     14.452
+           1.0     14.132
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1172,7 +1172,7 @@ Iteration # 117
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    820     2         0   13         0          34
   steptime[ms] runtime[s]
-           4.0     14.462
+           4.0     14.141
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1182,7 +1182,7 @@ Iteration # 118
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    817     2         0   13         0          34
   steptime[ms] runtime[s]
-           3.6     14.471
+           3.6     14.151
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1192,7 +1192,7 @@ Iteration # 119
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    817     2         0   13         0          35
   steptime[ms] runtime[s]
-           6.6     14.484
+           6.6     14.163
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1202,7 +1202,7 @@ Iteration # 120
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    817     2         0   13         0          35
   steptime[ms] runtime[s]
-           0.9     14.491
+           1.0     14.171
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1212,7 +1212,7 @@ Iteration # 121
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    813     2         0   13         0          35
   steptime[ms] runtime[s]
-           1.4     14.498
+           1.5     14.179
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1222,7 +1222,7 @@ Iteration # 122
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    813     2         0   13         0          35
   steptime[ms] runtime[s]
-           3.1     14.507
+           3.2     14.188
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1232,7 +1232,7 @@ Iteration # 123
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    813     2         0   13         0          35
   steptime[ms] runtime[s]
-           1.0     14.514
+           0.9     14.195
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1242,7 +1242,7 @@ Iteration # 124
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    806     1         0   14         0          36
   steptime[ms] runtime[s]
-        3420.2     17.941
+        3373.3     17.574
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1252,7 +1252,7 @@ Iteration # 125
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    806     1         0   14         0          36
   steptime[ms] runtime[s]
-           0.6     17.948
+           0.5     17.581
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1262,7 +1262,7 @@ Iteration # 126
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    805     2         0   14         0          38
   steptime[ms] runtime[s]
-           8.7     17.963
+           8.5     17.595
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1272,7 +1272,7 @@ Iteration # 127
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    804     2         0   14         0          38
   steptime[ms] runtime[s]
-           2.6     17.971
+           2.6     17.604
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1282,7 +1282,7 @@ Iteration # 128
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    800     2         0   14         0          39
   steptime[ms] runtime[s]
-           6.4     17.984
+           6.4     17.616
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1292,7 +1292,7 @@ Iteration # 129
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    794     1         0   14         0          40
   steptime[ms] runtime[s]
-           5.5     17.996
+           5.3     17.628
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1302,7 +1302,7 @@ Iteration # 130
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    790     1         0   14         0          40
   steptime[ms] runtime[s]
-           1.2     18.003
+           1.2     17.635
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1312,7 +1312,7 @@ Iteration # 131
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    787     0         0   15         0          40
   steptime[ms] runtime[s]
-           0.8     18.010
+           0.7     17.642
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1322,7 +1322,7 @@ Iteration # 132
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    787     0         0   15         0          40
   steptime[ms] runtime[s]
-           0.5     18.016
+           0.5     17.648
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1332,7 +1332,7 @@ Iteration # 133
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    787     1         0   15         0          40
   steptime[ms] runtime[s]
-           3.8     18.026
+           3.7     17.658
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1342,7 +1342,7 @@ Iteration # 134
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    787     1         0   15         0          40
   steptime[ms] runtime[s]
-           0.8     18.033
+           0.9     17.664
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1352,7 +1352,7 @@ Iteration # 135
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    787     1         0   15         0          40
   steptime[ms] runtime[s]
-           1.5     18.040
+           1.4     17.672
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1362,7 +1362,7 @@ Iteration # 136
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    787     1         0   15         0          40
   steptime[ms] runtime[s]
-           0.9     18.047
+           0.8     17.678
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1372,7 +1372,7 @@ Iteration # 137
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    786     2         0   15         0          40
   steptime[ms] runtime[s]
-           3.9     18.057
+           3.9     17.688
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1382,7 +1382,7 @@ Iteration # 138
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    786     2         0   15         0          40
   steptime[ms] runtime[s]
-           0.8     18.064
+           0.8     17.695
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1392,7 +1392,7 @@ Iteration # 139
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    786     2         0   15         0          40
   steptime[ms] runtime[s]
-           1.1     18.071
+           1.1     17.702
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1402,7 +1402,7 @@ Iteration # 140
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    779     3         0   15         0          40
   steptime[ms] runtime[s]
-           5.6     18.082
+           5.7     17.714
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1412,7 +1412,7 @@ Iteration # 141
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    778     3         0   15         0          40
   steptime[ms] runtime[s]
-           1.1     18.089
+           1.0     17.721
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1422,7 +1422,7 @@ Iteration # 142
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    774     2         0   15         0          40
   steptime[ms] runtime[s]
-           1.5     18.097
+           1.5     17.728
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1432,7 +1432,7 @@ Iteration # 143
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    773     2         0   15         0          40
   steptime[ms] runtime[s]
-           0.8     18.104
+           0.8     17.735
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1442,7 +1442,7 @@ Iteration # 144
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    771     2         0   15         0          40
   steptime[ms] runtime[s]
-           4.4     18.114
+           4.3     17.745
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1452,7 +1452,7 @@ Iteration # 145
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    771     2         0   15         0          40
   steptime[ms] runtime[s]
-           1.0     18.121
+           0.9     17.752
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1462,7 +1462,7 @@ Iteration # 146
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    766     2         0   15         0          40
   steptime[ms] runtime[s]
-           2.8     18.130
+           2.7     17.761
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1472,7 +1472,7 @@ Iteration # 147
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    761     1         0   16         0          41
   steptime[ms] runtime[s]
-           7.1     18.143
+           7.1     17.774
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1482,7 +1482,7 @@ Iteration # 148
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    753     1         0   17         0          43
   steptime[ms] runtime[s]
-          10.2     18.159
+          10.1     17.790
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1492,7 +1492,7 @@ Iteration # 149
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    753     2         0   17         0          43
   steptime[ms] runtime[s]
-           2.6     18.168
+           2.6     17.798
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1502,7 +1502,7 @@ Iteration # 150
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    750     1         0   17         0          43
   steptime[ms] runtime[s]
-           1.9     18.176
+           1.9     17.806
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1512,7 +1512,7 @@ Iteration # 151
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    750     1         0   17         0          44
   steptime[ms] runtime[s]
-           5.7     18.188
+           5.7     17.818
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1522,7 +1522,7 @@ Iteration # 152
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    749     2         0   17         0          44
   steptime[ms] runtime[s]
-           3.1     18.197
+           3.1     17.827
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1532,7 +1532,7 @@ Iteration # 153
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    743     1         0   17         0          44
   steptime[ms] runtime[s]
-           1.6     18.204
+           1.5     17.834
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1542,7 +1542,7 @@ Iteration # 154
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    743     1         0   17         0          44
   steptime[ms] runtime[s]
-           3.0     18.213
+           3.1     17.843
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1552,7 +1552,7 @@ Iteration # 155
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    742     1         0   17         0          44
   steptime[ms] runtime[s]
-           4.7     18.224
+           4.7     17.854
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1562,7 +1562,7 @@ Iteration # 156
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    742     1         0   17         0          44
   steptime[ms] runtime[s]
-           0.5     18.230
+           0.5     17.860
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1572,7 +1572,7 @@ Iteration # 157
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    738     1         0   17         0          44
   steptime[ms] runtime[s]
-           3.6     18.240
+           3.5     17.870
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1582,7 +1582,7 @@ Iteration # 158
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    738     1         0   17         0          44
   steptime[ms] runtime[s]
-           1.9     18.248
+           2.0     17.878
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1592,7 +1592,7 @@ Iteration # 159
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    735     1         0   17         0          44
   steptime[ms] runtime[s]
-           2.2     18.256
+           2.2     17.886
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1602,7 +1602,7 @@ Iteration # 160
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    735     1         0   17         0          44
   steptime[ms] runtime[s]
-           0.8     18.263
+           0.9     17.893
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1612,7 +1612,7 @@ Iteration # 161
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    732     1         0   17         0          45
   steptime[ms] runtime[s]
-           4.6     18.274
+           4.6     17.903
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1622,7 +1622,7 @@ Iteration # 162
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    732     1         0   17         0          46
   steptime[ms] runtime[s]
-           4.5     18.284
+           4.4     17.914
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1632,7 +1632,7 @@ Iteration # 163
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    732     1         0   17         0          46
   steptime[ms] runtime[s]
-           0.5     18.291
+           0.5     17.920
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1642,7 +1642,7 @@ Iteration # 164
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    732     1         0   17         0          46
   steptime[ms] runtime[s]
-           0.9     18.297
+           0.9     17.927
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1652,7 +1652,7 @@ Iteration # 165
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    729     0         0   17         0          46
   steptime[ms] runtime[s]
-           1.3     18.305
+           1.3     17.934
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1662,7 +1662,7 @@ Iteration # 166
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    729     0         0   17         0          46
   steptime[ms] runtime[s]
-           0.9     18.311
+           0.8     17.941
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1672,7 +1672,7 @@ Iteration # 167
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    729     1         0   17         0          46
   steptime[ms] runtime[s]
-           3.4     18.321
+           3.4     17.950
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1682,7 +1682,7 @@ Iteration # 168
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    729     1         0   17         0          46
   steptime[ms] runtime[s]
-           0.8     18.328
+           0.9     17.957
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1692,7 +1692,7 @@ Iteration # 169
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    729     1         0   17         0          46
   steptime[ms] runtime[s]
-           0.5     18.334
+           0.6     17.964
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1702,7 +1702,7 @@ Iteration # 170
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    725     1         0   17         0          46
   steptime[ms] runtime[s]
-           3.5     18.343
+           3.5     17.973
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1712,7 +1712,7 @@ Iteration # 171
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    721     0         0   17         0          46
   steptime[ms] runtime[s]
-           0.9     18.350
+           0.8     17.980
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1722,7 +1722,7 @@ Iteration # 172
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    721     0         0   17         0          46
   steptime[ms] runtime[s]
-           0.4     18.357
+           0.4     17.986
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1732,7 +1732,7 @@ Iteration # 173
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    720     1         0   17         0          46
   steptime[ms] runtime[s]
-           6.0     18.369
+           6.1     17.998
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1742,7 +1742,7 @@ Iteration # 174
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    708     1         0   17         0          46
   steptime[ms] runtime[s]
-           2.4     18.377
+           2.4     18.007
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1752,7 +1752,7 @@ Iteration # 175
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    704     0         0   17         0          46
   steptime[ms] runtime[s]
-           0.9     18.384
+           0.8     18.013
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1762,7 +1762,7 @@ Iteration # 176
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    697     1         0   17         0          46
   steptime[ms] runtime[s]
-           4.7     18.395
+           4.7     18.024
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1772,7 +1772,7 @@ Iteration # 177
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    697     1         0   17         0          46
   steptime[ms] runtime[s]
-           0.5     18.401
+           0.5     18.031
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1782,7 +1782,7 @@ Iteration # 178
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    697     1         0   17         0          46
   steptime[ms] runtime[s]
-           0.8     18.408
+           0.9     18.037
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1792,7 +1792,7 @@ Iteration # 179
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    682     1         0   18         0          46
   steptime[ms] runtime[s]
-           5.2     18.419
+           5.2     18.048
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1802,7 +1802,7 @@ Iteration # 180
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    669     1         0   18         0          46
   steptime[ms] runtime[s]
-           4.9     18.430
+           4.9     18.059
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1812,7 +1812,7 @@ Iteration # 181
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    660     1         0   18         0          46
   steptime[ms] runtime[s]
-           2.7     18.439
+           2.8     18.068
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1822,7 +1822,7 @@ Iteration # 182
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    660     2         0   18         0          47
   steptime[ms] runtime[s]
-           6.5     18.451
+           6.6     18.080
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1832,7 +1832,7 @@ Iteration # 183
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    659     2         0   18         0          47
   steptime[ms] runtime[s]
-           4.8     18.462
+           4.7     18.091
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1842,7 +1842,7 @@ Iteration # 184
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    657     4         0   18         0          47
   steptime[ms] runtime[s]
-           5.6     18.474
+           5.5     18.102
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1852,7 +1852,7 @@ Iteration # 185
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    650     1         0   18         0          47
   steptime[ms] runtime[s]
-           2.2     18.482
+           2.3     18.111
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1862,7 +1862,7 @@ Iteration # 186
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    644     1         0   18         0          47
   steptime[ms] runtime[s]
-           3.4     18.492
+           3.5     18.120
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1872,7 +1872,7 @@ Iteration # 187
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    644     1         0   18         0          47
   steptime[ms] runtime[s]
-           1.1     18.499
+           1.0     18.127
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1882,7 +1882,7 @@ Iteration # 188
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    642     1         0   18         0          47
   steptime[ms] runtime[s]
-           3.5     18.508
+           3.4     18.136
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1892,7 +1892,7 @@ Iteration # 189
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    642     1         0   18         0          47
   steptime[ms] runtime[s]
-           1.6     18.516
+           1.7     18.144
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1902,7 +1902,7 @@ Iteration # 190
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    639     1         0   18         0          47
   steptime[ms] runtime[s]
-           3.3     18.525
+           3.2     18.153
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1912,7 +1912,7 @@ Iteration # 191
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    629     0         0   19         0          48
   steptime[ms] runtime[s]
-           7.0     18.538
+           7.0     18.166
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1922,7 +1922,7 @@ Iteration # 192
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    629     0         0   19         0          48
   steptime[ms] runtime[s]
-           0.4     18.545
+           0.4     18.172
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1932,7 +1932,7 @@ Iteration # 193
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    629     1         0   19         0          49
   steptime[ms] runtime[s]
-           7.1     18.558
+           7.2     18.185
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1942,7 +1942,7 @@ Iteration # 194
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    629     1         0   19         0          49
   steptime[ms] runtime[s]
-           0.5     18.564
+           0.5     18.192
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1952,7 +1952,7 @@ Iteration # 195
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    629     1         0   19         0          49
   steptime[ms] runtime[s]
-           1.1     18.571
+           1.0     18.199
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1962,7 +1962,7 @@ Iteration # 196
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    624     1         0   19         0          49
   steptime[ms] runtime[s]
-           1.8     18.579
+           1.8     18.206
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1972,7 +1972,7 @@ Iteration # 197
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    623     2         0   19         0          49
   steptime[ms] runtime[s]
-           3.8     18.589
+           3.7     18.216
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1982,7 +1982,7 @@ Iteration # 198
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    623     2         0   19         0          49
   steptime[ms] runtime[s]
-           2.3     18.597
+           2.3     18.224
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1992,7 +1992,7 @@ Iteration # 199
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    621     2         0   19         0          49
   steptime[ms] runtime[s]
-           3.1     18.606
+           3.2     18.233
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2002,7 +2002,7 @@ Iteration # 200
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    616     2         0   19         0          49
   steptime[ms] runtime[s]
-           3.1     18.615
+           3.1     18.242
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2012,7 +2012,7 @@ Iteration # 201
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    611     2         0   19         0          49
   steptime[ms] runtime[s]
-           1.4     18.622
+           1.4     18.250
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2022,7 +2022,7 @@ Iteration # 202
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    610     2         0   19         0          49
   steptime[ms] runtime[s]
-           1.4     18.630
+           1.5     18.257
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2032,7 +2032,7 @@ Iteration # 203
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    610     2         0   19         0          49
   steptime[ms] runtime[s]
-           0.6     18.636
+           0.6     18.264
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2042,7 +2042,7 @@ Iteration # 204
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    610     2         0   19         0          49
   steptime[ms] runtime[s]
-           1.0     18.643
+           0.9     18.270
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2052,7 +2052,7 @@ Iteration # 205
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    607     1         0   19         0          49
   steptime[ms] runtime[s]
-           3.4     18.653
+           3.4     18.280
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2062,7 +2062,7 @@ Iteration # 206
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    604     1         0   19         0          49
   steptime[ms] runtime[s]
-           4.1     18.663
+           4.0     18.290
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2072,7 +2072,7 @@ Iteration # 207
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    600     0         0   20         0          49
   steptime[ms] runtime[s]
-           1.3     18.670
+           1.4     18.297
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2082,7 +2082,7 @@ Iteration # 208
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    600     1         0   20         0          49
   steptime[ms] runtime[s]
-           2.1     18.678
+           2.1     18.305
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2092,7 +2092,7 @@ Iteration # 209
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    597     2         0   20         0          49
   steptime[ms] runtime[s]
-           2.2     18.686
+           2.1     18.313
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2102,7 +2102,7 @@ Iteration # 210
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    594     0         0   20         0          49
   steptime[ms] runtime[s]
-           3.6     18.696
+           3.6     18.322
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2112,7 +2112,7 @@ Iteration # 211
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    594     1         0   20         0          49
   steptime[ms] runtime[s]
-           2.4     18.704
+           2.5     18.331
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2122,7 +2122,7 @@ Iteration # 212
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    594     2         0   20         0          49
   steptime[ms] runtime[s]
-           4.6     18.715
+           4.6     18.341
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2132,7 +2132,7 @@ Iteration # 213
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    589     2         0   20         0          49
   steptime[ms] runtime[s]
-           7.1     18.728
+           7.1     18.354
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2142,7 +2142,7 @@ Iteration # 214
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    585     2         0   20         0          49
   steptime[ms] runtime[s]
-           1.4     18.735
+           1.3     18.361
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2152,7 +2152,7 @@ Iteration # 215
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    584     3         0   20         0          49
   steptime[ms] runtime[s]
-           2.9     18.744
+           3.0     18.370
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2162,7 +2162,7 @@ Iteration # 216
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    584     4         0   20         0          49
   steptime[ms] runtime[s]
-           3.5     18.754
+           3.5     18.380
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2172,7 +2172,7 @@ Iteration # 217
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    575     2         0   20         0          49
   steptime[ms] runtime[s]
-           3.1     18.763
+           3.2     18.389
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2182,7 +2182,7 @@ Iteration # 218
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    570     2         0   20         0          49
   steptime[ms] runtime[s]
-           3.6     18.773
+           3.6     18.398
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2192,7 +2192,7 @@ Iteration # 219
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    560     1         0   20         0          49
   steptime[ms] runtime[s]
-           1.9     18.780
+           2.0     18.406
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2202,7 +2202,7 @@ Iteration # 220
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    558     0         0   21         0          49
   steptime[ms] runtime[s]
-         833.5     19.620
+         852.7     19.265
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2212,7 +2212,7 @@ Iteration # 221
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    558     0         0   21         0          49
   steptime[ms] runtime[s]
-           0.8     19.627
+           0.8     19.272
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2222,7 +2222,7 @@ Iteration # 222
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    558     1         0   21         0          49
   steptime[ms] runtime[s]
-           1.8     19.635
+           1.9     19.280
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2232,7 +2232,7 @@ Iteration # 223
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    554     1         0   21         0          49
   steptime[ms] runtime[s]
-           1.2     19.642
+           1.2     19.287
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2242,7 +2242,7 @@ Iteration # 224
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    552     1         0   22         0          49
   steptime[ms] runtime[s]
-           2.6     19.650
+           2.6     19.295
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2252,7 +2252,7 @@ Iteration # 225
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    547     1         0   22         0          49
   steptime[ms] runtime[s]
-           3.9     19.660
+           3.9     19.305
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2262,7 +2262,7 @@ Iteration # 226
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    544     1         0   22         0          49
   steptime[ms] runtime[s]
-           2.1     19.668
+           2.1     19.313
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2272,7 +2272,7 @@ Iteration # 227
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    544     1         0   22         0          49
   steptime[ms] runtime[s]
-           0.5     19.675
+           0.5     19.320
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2282,7 +2282,7 @@ Iteration # 228
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    543     1         0   22         0          49
   steptime[ms] runtime[s]
-           0.8     19.681
+           0.7     19.326
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2292,7 +2292,7 @@ Iteration # 229
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    537     1         0   22         0          49
   steptime[ms] runtime[s]
-           1.6     19.689
+           1.6     19.333
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2302,7 +2302,7 @@ Iteration # 230
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    537     2         0   22         0          49
   steptime[ms] runtime[s]
-           3.3     19.698
+           3.4     19.343
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2312,7 +2312,7 @@ Iteration # 231
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    533     2         0   22         0          49
   steptime[ms] runtime[s]
-           2.8     19.707
+           2.8     19.352
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2322,7 +2322,7 @@ Iteration # 232
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    526     1         0   22         0          49
   steptime[ms] runtime[s]
-           1.9     19.715
+           1.9     19.359
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2332,7 +2332,7 @@ Iteration # 233
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    523     0         0   22         0          49
   steptime[ms] runtime[s]
-           0.7     19.722
+           0.6     19.366
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2342,7 +2342,7 @@ Iteration # 234
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    523     0         0   22         0          49
   steptime[ms] runtime[s]
-           0.4     19.728
+           0.4     19.372
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2352,7 +2352,7 @@ Iteration # 235
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    523     0         0   22         0          49
   steptime[ms] runtime[s]
-           0.5     19.734
+           0.5     19.378
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2362,7 +2362,7 @@ Iteration # 236
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    523     0         0   22         0          49
   steptime[ms] runtime[s]
-           0.4     19.741
+           0.4     19.385
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2372,7 +2372,7 @@ Iteration # 237
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    523     1         0   22         0          49
   steptime[ms] runtime[s]
-           0.9     19.748
+           0.8     19.391
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2382,7 +2382,7 @@ Iteration # 238
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    523     1         0   22         0          49
   steptime[ms] runtime[s]
-           1.0     19.755
+           0.8     19.398
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2392,7 +2392,7 @@ Iteration # 239
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    522     1         0   22         0          49
   steptime[ms] runtime[s]
-           2.3     19.763
+           2.3     19.406
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2402,7 +2402,7 @@ Iteration # 240
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    518     1         0   22         0          49
   steptime[ms] runtime[s]
-           1.4     19.771
+           1.3     19.413
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2412,7 +2412,7 @@ Iteration # 241
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    515     1         0   22         0          49
   steptime[ms] runtime[s]
-           1.0     19.778
+           1.0     19.420
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2422,7 +2422,7 @@ Iteration # 242
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    512     0         0   23         0          49
   steptime[ms] runtime[s]
-           0.8     19.784
+           0.7     19.427
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2432,7 +2432,7 @@ Iteration # 243
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    512     0         0   23         0          50
   steptime[ms] runtime[s]
-           3.9     19.794
+           3.8     19.436
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2442,7 +2442,7 @@ Iteration # 244
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    512     0         0   23         0          50
   steptime[ms] runtime[s]
-           0.4     19.801
+           0.4     19.443
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2452,7 +2452,7 @@ Iteration # 245
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    505     1         0   23         0          50
   steptime[ms] runtime[s]
-           7.7     19.814
+           7.6     19.456
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2462,7 +2462,7 @@ Iteration # 246
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    504     1         0   23         0          50
   steptime[ms] runtime[s]
-           1.0     19.821
+           1.0     19.463
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2472,7 +2472,7 @@ Iteration # 247
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    504     1         0   23         0          51
   steptime[ms] runtime[s]
-           7.9     19.835
+           7.9     19.477
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2482,7 +2482,7 @@ Iteration # 248
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    500     0         0   24         0          51
   steptime[ms] runtime[s]
-           1.0     19.842
+           0.9     19.484
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2492,7 +2492,7 @@ Iteration # 249
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    500     0         0   24         0          51
   steptime[ms] runtime[s]
-           0.4     19.848
+           0.4     19.490
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2502,7 +2502,7 @@ Iteration # 250
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    500     1         0   24         0          51
   steptime[ms] runtime[s]
-           2.7     19.857
+           2.8     19.499
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2512,7 +2512,7 @@ Iteration # 251
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    500     1         0   24         0          51
   steptime[ms] runtime[s]
-           2.7     19.866
+           2.7     19.507
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2522,7 +2522,7 @@ Iteration # 252
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    497     2         0   24         0          51
   steptime[ms] runtime[s]
-           4.8     19.876
+           4.8     19.518
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2532,7 +2532,7 @@ Iteration # 253
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    483     2         0   25         0          51
   steptime[ms] runtime[s]
-         382.5     20.265
+         383.1     19.907
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2542,7 +2542,7 @@ Iteration # 254
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    479     3         0   25         0          51
   steptime[ms] runtime[s]
-           2.9     20.274
+           2.9     19.916
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2552,7 +2552,7 @@ Iteration # 255
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    476     3         0   25         0          51
   steptime[ms] runtime[s]
-           2.9     20.283
+           2.9     19.925
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2562,7 +2562,7 @@ Iteration # 256
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    473     3         0   25         0          51
   steptime[ms] runtime[s]
-           2.9     20.292
+           2.9     19.934
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2572,7 +2572,7 @@ Iteration # 257
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    468     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.5     20.299
+           1.5     19.941
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2582,7 +2582,7 @@ Iteration # 258
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    465     2         0   26         0          51
   steptime[ms] runtime[s]
-           3.8     20.309
+           3.9     19.951
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2592,7 +2592,7 @@ Iteration # 259
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    464     1         0   26         0          51
   steptime[ms] runtime[s]
-           2.6     20.318
+           2.5     19.959
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2602,7 +2602,7 @@ Iteration # 260
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    460     2         0   26         0          51
   steptime[ms] runtime[s]
-           3.2     20.327
+           3.2     19.968
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2612,7 +2612,7 @@ Iteration # 261
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    456     2         0   26         0          51
   steptime[ms] runtime[s]
-           5.8     20.339
+           5.8     19.980
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2622,7 +2622,7 @@ Iteration # 262
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    455     3         0   26         0          51
   steptime[ms] runtime[s]
-           3.4     20.348
+           3.4     19.990
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2632,7 +2632,7 @@ Iteration # 263
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    447     3         0   26         0          51
   steptime[ms] runtime[s]
-           8.8     20.363
+           8.7     20.005
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2642,7 +2642,7 @@ Iteration # 264
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    446     3         0   26         0          51
   steptime[ms] runtime[s]
-           1.1     20.370
+           1.1     20.011
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2652,7 +2652,7 @@ Iteration # 265
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    438     2         0   26         0          51
   steptime[ms] runtime[s]
-           2.1     20.378
+           2.1     20.019
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2662,7 +2662,7 @@ Iteration # 266
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    431     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.7     20.386
+           1.8     20.027
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2672,7 +2672,7 @@ Iteration # 267
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    430     3         0   26         0          51
   steptime[ms] runtime[s]
-           2.6     20.394
+           2.6     20.036
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2682,7 +2682,7 @@ Iteration # 268
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    425     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.6     20.402
+           1.6     20.043
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2692,7 +2692,7 @@ Iteration # 269
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    421     2         0   26         0          51
   steptime[ms] runtime[s]
-           2.0     20.410
+           2.0     20.051
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2702,7 +2702,7 @@ Iteration # 270
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    421     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.6     20.416
+           0.6     20.057
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2712,7 +2712,7 @@ Iteration # 271
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    417     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.9     20.423
+           0.9     20.064
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2722,7 +2722,7 @@ Iteration # 272
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    415     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.8     20.430
+           0.8     20.071
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2732,7 +2732,7 @@ Iteration # 273
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    411     2         0   26         0          51
   steptime[ms] runtime[s]
-           3.9     20.439
+           3.9     20.081
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2742,7 +2742,7 @@ Iteration # 274
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    411     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.3     20.447
+           1.3     20.088
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2752,7 +2752,7 @@ Iteration # 275
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    407     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.4     20.454
+           1.4     20.095
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2762,7 +2762,7 @@ Iteration # 276
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    406     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.8     20.461
+           0.8     20.102
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2772,7 +2772,7 @@ Iteration # 277
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    398     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.5     20.468
+           1.5     20.109
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2782,7 +2782,7 @@ Iteration # 278
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    392     1         0   26         0          51
   steptime[ms] runtime[s]
-           4.0     20.478
+           3.9     20.119
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2792,7 +2792,7 @@ Iteration # 279
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    391     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.7     20.485
+           0.7     20.126
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2802,7 +2802,7 @@ Iteration # 280
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    391     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.5     20.491
+           0.5     20.132
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2812,7 +2812,7 @@ Iteration # 281
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    389     2         0   26         0          51
   steptime[ms] runtime[s]
-           2.6     20.500
+           2.6     20.141
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2822,7 +2822,7 @@ Iteration # 282
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    389     2         0   26         0          51
   steptime[ms] runtime[s]
-           2.4     20.508
+           2.3     20.149
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2832,7 +2832,7 @@ Iteration # 283
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    385     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.5     20.515
+           1.5     20.156
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2842,7 +2842,7 @@ Iteration # 284
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    382     2         0   26         0          51
   steptime[ms] runtime[s]
-           3.2     20.525
+           3.1     20.165
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2852,7 +2852,7 @@ Iteration # 285
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    380     3         0   26         0          51
   steptime[ms] runtime[s]
-           1.8     20.532
+           1.9     20.173
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2862,7 +2862,7 @@ Iteration # 286
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    375     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.5     20.540
+           1.5     20.180
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2872,7 +2872,7 @@ Iteration # 287
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    371     2         0   26         0          51
   steptime[ms] runtime[s]
-           3.4     20.549
+           3.4     20.190
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2882,7 +2882,7 @@ Iteration # 288
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    367     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.4     20.556
+           1.4     20.197
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2892,7 +2892,7 @@ Iteration # 289
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    364     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.1     20.564
+           1.0     20.204
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2902,7 +2902,7 @@ Iteration # 290
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    361     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.1     20.571
+           1.1     20.211
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2912,7 +2912,7 @@ Iteration # 291
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    359     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.8     20.577
+           0.8     20.217
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2922,7 +2922,7 @@ Iteration # 292
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    358     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.7     20.584
+           0.6     20.224
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2932,7 +2932,7 @@ Iteration # 293
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    358     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.1     20.591
+           1.1     20.231
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2942,7 +2942,7 @@ Iteration # 294
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    357     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.0     20.598
+           1.0     20.238
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2952,7 +2952,7 @@ Iteration # 295
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    357     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.2     20.605
+           1.2     20.245
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2962,7 +2962,7 @@ Iteration # 296
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    354     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.8     20.613
+           1.9     20.253
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2972,7 +2972,7 @@ Iteration # 297
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    354     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.8     20.621
+           1.9     20.260
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2982,7 +2982,7 @@ Iteration # 298
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    354     2         0   26         0          51
   steptime[ms] runtime[s]
-           2.5     20.629
+           2.5     20.269
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2992,7 +2992,7 @@ Iteration # 299
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    354     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.7     20.637
+           1.6     20.276
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3002,7 +3002,7 @@ Iteration # 300
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    353     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.8     20.643
+           0.7     20.283
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3012,7 +3012,7 @@ Iteration # 301
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    353     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.6     20.650
+           0.6     20.289
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3022,7 +3022,7 @@ Iteration # 302
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    353     3         0   26         0          51
   steptime[ms] runtime[s]
-           0.9     20.657
+           0.9     20.296
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3032,7 +3032,7 @@ Iteration # 303
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    350     3         0   26         0          51
   steptime[ms] runtime[s]
-           2.3     20.665
+           2.3     20.304
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3042,7 +3042,7 @@ Iteration # 304
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    349     3         0   26         0          51
   steptime[ms] runtime[s]
-           4.4     20.675
+           4.3     20.314
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3052,7 +3052,7 @@ Iteration # 305
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    344     3         0   26         0          51
   steptime[ms] runtime[s]
-           3.6     20.685
+           3.6     20.324
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3062,7 +3062,7 @@ Iteration # 306
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    343     4         0   26         0          51
   steptime[ms] runtime[s]
-           3.8     20.694
+           3.9     20.334
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3072,7 +3072,7 @@ Iteration # 307
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    338     3         0   26         0          51
   steptime[ms] runtime[s]
-           1.7     20.702
+           1.7     20.341
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3082,7 +3082,7 @@ Iteration # 308
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    335     3         0   26         0          51
   steptime[ms] runtime[s]
-           1.2     20.709
+           1.2     20.349
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3092,7 +3092,7 @@ Iteration # 309
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    330     3         0   26         0          51
   steptime[ms] runtime[s]
-           1.4     20.716
+           1.4     20.356
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3102,7 +3102,7 @@ Iteration # 310
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    328     3         0   26         0          51
   steptime[ms] runtime[s]
-           2.8     20.725
+           2.9     20.365
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3112,7 +3112,7 @@ Iteration # 311
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    327     3         0   26         0          51
   steptime[ms] runtime[s]
-           2.5     20.734
+           2.5     20.373
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3122,7 +3122,7 @@ Iteration # 312
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    326     3         0   26         0          51
   steptime[ms] runtime[s]
-           1.0     20.740
+           1.0     20.380
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3132,7 +3132,7 @@ Iteration # 313
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    325     3         0   26         0          51
   steptime[ms] runtime[s]
-           1.0     20.747
+           1.0     20.387
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3142,7 +3142,7 @@ Iteration # 314
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    321     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.0     20.754
+           1.0     20.393
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3152,7 +3152,7 @@ Iteration # 315
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    321     2         0   26         0          51
   steptime[ms] runtime[s]
-           4.3     20.764
+           4.4     20.404
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3162,7 +3162,7 @@ Iteration # 316
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    318     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.9     20.771
+           1.0     20.411
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3172,7 +3172,7 @@ Iteration # 317
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    318     2         0   26         0          51
   steptime[ms] runtime[s]
-           3.8     20.781
+           3.8     20.420
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3182,7 +3182,7 @@ Iteration # 318
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    318     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.8     20.788
+           0.7     20.427
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3192,7 +3192,7 @@ Iteration # 319
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    318     3         0   26         0          51
   steptime[ms] runtime[s]
-           2.1     20.796
+           2.2     20.435
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3202,7 +3202,7 @@ Iteration # 320
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    318     2         0   26         0          51
   steptime[ms] runtime[s]
-           3.1     20.805
+           3.0     20.444
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3212,7 +3212,7 @@ Iteration # 321
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    316     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.7     20.812
+           1.7     20.451
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3222,7 +3222,7 @@ Iteration # 322
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    307     2         0   26         0          51
   steptime[ms] runtime[s]
-           2.8     20.821
+           2.6     20.460
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3232,7 +3232,7 @@ Iteration # 323
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    306     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.8     20.828
+           0.8     20.467
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3242,7 +3242,7 @@ Iteration # 324
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    306     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.9     20.835
+           1.0     20.473
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3252,7 +3252,7 @@ Iteration # 325
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    302     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.9     20.843
+           1.9     20.481
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3262,7 +3262,7 @@ Iteration # 326
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    302     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.6     20.849
+           0.6     20.488
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3272,7 +3272,7 @@ Iteration # 327
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    302     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.0     20.856
+           0.9     20.494
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3282,7 +3282,7 @@ Iteration # 328
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    299     2         0   26         0          51
   steptime[ms] runtime[s]
-           3.3     20.865
+           3.2     20.503
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3292,7 +3292,7 @@ Iteration # 329
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    298     2         0   26         0          51
   steptime[ms] runtime[s]
-           0.8     20.872
+           0.8     20.510
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3302,7 +3302,7 @@ Iteration # 330
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    295     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.1     20.879
+           1.1     20.517
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3312,7 +3312,7 @@ Iteration # 331
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    292     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.1     20.886
+           1.0     20.524
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3322,7 +3322,7 @@ Iteration # 332
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    289     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.8     20.893
+           0.7     20.531
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3332,7 +3332,7 @@ Iteration # 333
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    289     2         0   26         0          51
   steptime[ms] runtime[s]
-           2.6     20.901
+           2.5     20.539
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3342,7 +3342,7 @@ Iteration # 334
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    286     1         0   26         0          51
   steptime[ms] runtime[s]
-           1.0     20.908
+           1.0     20.546
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3352,7 +3352,7 @@ Iteration # 335
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    286     1         0   26         0          51
   steptime[ms] runtime[s]
-           0.5     20.914
+           0.5     20.552
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3362,7 +3362,7 @@ Iteration # 336
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    284     2         0   26         0          51
   steptime[ms] runtime[s]
-           7.0     20.927
+           7.0     20.565
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3372,7 +3372,7 @@ Iteration # 337
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    282     2         0   26         0          51
   steptime[ms] runtime[s]
-           1.2     20.934
+           1.1     20.572
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3382,7 +3382,7 @@ Iteration # 338
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    281     2         0   26         0          51
   steptime[ms] runtime[s]
-           2.3     20.943
+           2.3     20.580
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3392,7 +3392,7 @@ Iteration # 339
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    276     1         0   27         0          51
   steptime[ms] runtime[s]
-          48.2     20.997
+          51.9     20.638
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3402,7 +3402,7 @@ Iteration # 340
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    273     1         0   27         0          51
   steptime[ms] runtime[s]
-           1.6     21.004
+           1.6     20.646
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3412,7 +3412,7 @@ Iteration # 341
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    273     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.5     21.011
+           0.5     20.652
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3422,7 +3422,7 @@ Iteration # 342
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    273     1         0   27         0          51
   steptime[ms] runtime[s]
-           1.3     21.018
+           1.3     20.659
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3432,7 +3432,7 @@ Iteration # 343
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    270     1         0   27         0          51
   steptime[ms] runtime[s]
-           1.0     21.025
+           1.0     20.666
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3442,7 +3442,7 @@ Iteration # 344
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    266     2         0   27         0          51
   steptime[ms] runtime[s]
-           3.8     21.035
+           3.8     20.676
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3452,7 +3452,7 @@ Iteration # 345
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    264     2         0   27         0          51
   steptime[ms] runtime[s]
-           3.2     21.044
+           3.2     20.685
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3462,7 +3462,7 @@ Iteration # 346
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    263     2         0   27         0          51
   steptime[ms] runtime[s]
-           0.8     21.051
+           0.7     20.692
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3472,7 +3472,7 @@ Iteration # 347
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    262     2         0   27         0          51
   steptime[ms] runtime[s]
-           0.8     21.057
+           0.8     20.698
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3482,7 +3482,7 @@ Iteration # 348
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    256     1         0   27         0          51
   steptime[ms] runtime[s]
-           1.8     21.065
+           1.7     20.706
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3492,7 +3492,7 @@ Iteration # 349
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    254     2         0   27         0          51
   steptime[ms] runtime[s]
-           1.9     21.073
+           1.9     20.714
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3502,7 +3502,7 @@ Iteration # 350
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    254     2         0   27         0          51
   steptime[ms] runtime[s]
-           1.4     21.080
+           1.4     20.721
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3512,7 +3512,7 @@ Iteration # 351
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    254     2         0   27         0          51
   steptime[ms] runtime[s]
-           1.5     21.088
+           1.5     20.728
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3522,7 +3522,7 @@ Iteration # 352
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    254     2         0   27         0          51
   steptime[ms] runtime[s]
-           1.1     21.094
+           1.1     20.735
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3532,7 +3532,7 @@ Iteration # 353
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    254     3         0   27         0          51
   steptime[ms] runtime[s]
-           1.6     21.102
+           1.6     20.743
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3542,7 +3542,7 @@ Iteration # 354
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    254     2         0   27         0          51
   steptime[ms] runtime[s]
-           2.9     21.111
+           2.8     20.751
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3552,7 +3552,7 @@ Iteration # 355
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    250     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.9     21.118
+           0.9     20.758
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3562,7 +3562,7 @@ Iteration # 356
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    249     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.7     21.124
+           0.7     20.765
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3572,7 +3572,7 @@ Iteration # 357
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    248     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.7     21.131
+           0.7     20.771
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3582,7 +3582,7 @@ Iteration # 358
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    247     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.7     21.137
+           0.7     20.778
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3592,7 +3592,7 @@ Iteration # 359
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    246     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.8     21.144
+           0.7     20.784
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3602,7 +3602,7 @@ Iteration # 360
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    242     1         0   27         0          51
   steptime[ms] runtime[s]
-           3.4     21.153
+           3.5     20.794
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3612,7 +3612,7 @@ Iteration # 361
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    239     2         0   27         0          51
   steptime[ms] runtime[s]
-           2.8     21.162
+           2.7     20.802
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3622,7 +3622,7 @@ Iteration # 362
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    237     1         0   27         0          51
   steptime[ms] runtime[s]
-           1.9     21.170
+           1.8     20.810
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3632,7 +3632,7 @@ Iteration # 363
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    237     1         0   27         0          51
   steptime[ms] runtime[s]
-           2.7     21.178
+           2.7     20.819
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3642,7 +3642,7 @@ Iteration # 364
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    237     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.6     21.185
+           0.6     20.825
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3652,7 +3652,7 @@ Iteration # 365
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    237     2         0   27         0          51
   steptime[ms] runtime[s]
-           1.2     21.192
+           1.2     20.832
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3662,7 +3662,7 @@ Iteration # 366
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    237     3         0   27         0          51
   steptime[ms] runtime[s]
-           1.6     21.199
+           1.6     20.840
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3672,7 +3672,7 @@ Iteration # 367
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    237     3         0   27         0          51
   steptime[ms] runtime[s]
-           1.1     21.206
+           1.1     20.847
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3682,7 +3682,7 @@ Iteration # 368
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    236     2         0   27         0          51
   steptime[ms] runtime[s]
-           2.5     21.215
+           2.5     20.855
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3692,7 +3692,7 @@ Iteration # 369
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    236     2         0   27         0          51
   steptime[ms] runtime[s]
-           1.1     21.222
+           1.1     20.862
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3702,7 +3702,7 @@ Iteration # 370
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    235     2         0   27         0          51
   steptime[ms] runtime[s]
-           0.8     21.229
+           0.8     20.869
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3712,7 +3712,7 @@ Iteration # 371
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    229     1         0   27         0          51
   steptime[ms] runtime[s]
-           1.2     21.236
+           1.2     20.876
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3722,7 +3722,7 @@ Iteration # 372
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    229     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.5     21.242
+           0.5     20.882
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3732,7 +3732,7 @@ Iteration # 373
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    229     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.5     21.248
+           0.5     20.888
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3742,7 +3742,7 @@ Iteration # 374
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    227     1         0   27         0          51
   steptime[ms] runtime[s]
-           0.9     21.255
+           0.8     20.895
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3752,7 +3752,7 @@ Iteration # 375
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    227     2         0   27         0          51
   steptime[ms] runtime[s]
-           2.0     21.263
+           2.1     20.903
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3762,7 +3762,7 @@ Iteration # 376
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    225     2         0   27         0          51
   steptime[ms] runtime[s]
-           2.7     21.272
+           2.7     20.911
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3772,7 +3772,7 @@ Iteration # 377
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    225     3         0   27         0          51
   steptime[ms] runtime[s]
-           0.8     21.278
+           0.7     20.918
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3782,7 +3782,7 @@ Iteration # 378
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    225     2         0   27         0          51
   steptime[ms] runtime[s]
-           2.0     21.286
+           1.9     20.926
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3792,7 +3792,7 @@ Iteration # 379
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    222     2         0   28         0          51
   steptime[ms] runtime[s]
-           3.1     21.295
+           3.1     20.935
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3802,7 +3802,7 @@ Iteration # 380
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    222     2         0   28         0          51
   steptime[ms] runtime[s]
-           1.1     21.302
+           1.1     20.942
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3812,7 +3812,7 @@ Iteration # 381
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    219     2         0   28         0          51
   steptime[ms] runtime[s]
-           2.9     21.311
+           2.9     20.951
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3822,7 +3822,7 @@ Iteration # 382
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    218     3         0   28         0          51
   steptime[ms] runtime[s]
-           2.6     21.319
+           2.6     20.959
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3832,7 +3832,7 @@ Iteration # 383
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    217     3         0   28         0          51
   steptime[ms] runtime[s]
-           0.9     21.326
+           0.8     20.966
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3842,7 +3842,7 @@ Iteration # 384
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    215     3         0   28         0          51
   steptime[ms] runtime[s]
-           2.7     21.335
+           2.8     20.974
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3852,7 +3852,7 @@ Iteration # 385
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    212     3         0   28         0          51
   steptime[ms] runtime[s]
-           1.2     21.342
+           1.2     20.982
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3862,7 +3862,7 @@ Iteration # 386
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    209     2         0   28         0          51
   steptime[ms] runtime[s]
-           1.3     21.349
+           1.2     20.989
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3872,7 +3872,7 @@ Iteration # 387
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    208     2         0   28         0          51
   steptime[ms] runtime[s]
-           3.5     21.359
+           3.6     20.998
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3882,7 +3882,7 @@ Iteration # 388
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    207     2         0   28         0          51
   steptime[ms] runtime[s]
-           2.8     21.367
+           2.7     21.007
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3892,7 +3892,7 @@ Iteration # 389
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    206     2         0   28         0          51
   steptime[ms] runtime[s]
-           3.0     21.376
+           3.0     21.016
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3902,7 +3902,7 @@ Iteration # 390
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    202     1         0   28         0          51
   steptime[ms] runtime[s]
-           0.9     21.383
+           0.9     21.023
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3912,7 +3912,7 @@ Iteration # 391
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    202     1         0   28         0          51
   steptime[ms] runtime[s]
-           0.5     21.390
+           0.5     21.029
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3922,7 +3922,7 @@ Iteration # 392
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    202     2         0   28         0          51
   steptime[ms] runtime[s]
-           3.5     21.399
+           3.6     21.038
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3932,7 +3932,7 @@ Iteration # 393
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    198     1         0   28         0          51
   steptime[ms] runtime[s]
-           3.6     21.409
+           3.5     21.048
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3942,7 +3942,7 @@ Iteration # 394
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    198     1         0   28         0          51
   steptime[ms] runtime[s]
-           0.8     21.415
+           0.8     21.054
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3952,7 +3952,7 @@ Iteration # 395
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    196     2         0   28         0          51
   steptime[ms] runtime[s]
-           5.2     21.427
+           5.3     21.066
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3962,7 +3962,7 @@ Iteration # 396
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    196     2         0   28         0          51
   steptime[ms] runtime[s]
-           3.9     21.436
+           3.8     21.075
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3972,7 +3972,7 @@ Iteration # 397
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    192     2         0   28         0          51
   steptime[ms] runtime[s]
-           1.4     21.444
+           1.3     21.082
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3982,7 +3982,7 @@ Iteration # 398
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    188     3         0   28         0          51
   steptime[ms] runtime[s]
-           2.9     21.453
+           3.0     21.091
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3992,7 +3992,7 @@ Iteration # 399
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    188     3         0   28         0          51
   steptime[ms] runtime[s]
-           2.1     21.461
+           2.1     21.099
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4002,7 +4002,7 @@ Iteration # 400
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    185     3         0   28         0          51
   steptime[ms] runtime[s]
-           2.7     21.469
+           2.7     21.108
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4012,7 +4012,7 @@ Iteration # 401
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    183     3         0   28         0          51
   steptime[ms] runtime[s]
-           3.9     21.479
+           3.7     21.118
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4022,7 +4022,7 @@ Iteration # 402
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    182     3         0   28         0          51
   steptime[ms] runtime[s]
-           2.2     21.487
+           2.2     21.126
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4032,7 +4032,7 @@ Iteration # 403
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    180     3         0   28         0          51
   steptime[ms] runtime[s]
-           2.6     21.496
+           2.7     21.134
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4042,7 +4042,7 @@ Iteration # 404
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    179     3         0   28         0          51
   steptime[ms] runtime[s]
-           0.9     21.503
+           0.8     21.141
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4052,7 +4052,7 @@ Iteration # 405
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    175     2         0   28         0          51
   steptime[ms] runtime[s]
-           2.3     21.511
+           2.3     21.149
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4062,7 +4062,7 @@ Iteration # 406
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    173     2         0   28         0          51
   steptime[ms] runtime[s]
-           2.9     21.520
+           2.7     21.158
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4072,7 +4072,7 @@ Iteration # 407
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    173     2         0   28         0          51
   steptime[ms] runtime[s]
-           2.9     21.529
+           2.9     21.167
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4082,7 +4082,7 @@ Iteration # 408
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    171     2         0   28         0          51
   steptime[ms] runtime[s]
-           2.5     21.537
+           2.5     21.175
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4092,7 +4092,7 @@ Iteration # 409
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    169     2         0   28         0          51
   steptime[ms] runtime[s]
-           1.0     21.544
+           1.0     21.182
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4102,7 +4102,7 @@ Iteration # 410
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    166     1         0   28         0          51
   steptime[ms] runtime[s]
-           0.9     21.551
+           0.7     21.189
 
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -4112,10 +4112,10 @@ Iteration # 411
   N_BH N_BBH N_Triples N_me N_tdeBHWD N_tdeBHstar
    166     1         0   28         0          51
   steptime[ms] runtime[s]
-           0.5     21.557
+           0.5     21.195
 
 
 REDSHIFT 0 REACHED
-END OF SIMULATION. RUNTIME: 21.6 s
+END OF SIMULATION. RUNTIME: 21.3 s
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ $\tt Rapster$ stands for $\rm RAPid\ cluSTER$ evolution.
 
 Author: Konstantinos Kritos <kkritos1@jhu.edu>
 
-Version: 2.9.5, May 25, 2026.
+Version: 2.9.6, June 4, 2026.
 (Thanks to Tousif Islam for helping modularize this repository!)
 
 ![LOGO](.assets/LOGO.png)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapster"
-version = "2.9.5"
+version = "2.9.6"
 description = "Rapid population synthesis package for compact object coalescences and tidal disruptions in dense star clusters."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/rapster/binary_evolution.py
+++ b/rapster/binary_evolution.py
@@ -255,8 +255,7 @@ def evolve_BBHs(seed, t, z, dt, zCl_form, binaries, hardening, mergers, mBH, sBH
                     # find index location of binary:
                     k2 = np.squeeze(np.where(binaries[:, 2]==a2))+0
                     
-                    if isinstance(k2, np.ndarray):
-                        k2 = k2[0]
+                    k2 = int(np.atleast_1d(k2)[0])
                         
                     # order based on hardness:
                     if a1 < a2:
@@ -356,8 +355,7 @@ def evolve_BBHs(seed, t, z, dt, zCl_form, binaries, hardening, mergers, mBH, sBH
                     
                     k3 = np.squeeze(np.where(mBH==m3))+0
                     
-                    if isinstance(k3, np.ndarray):
-                        k3 = k3[0]
+                    k3 = int(np.atleast_1d(k3)[0])
                     
                     s3 = sBH[k3]
                     g3 = gBH[k3]

--- a/rapster/cluster_evolution.py
+++ b/rapster/cluster_evolution.py
@@ -825,10 +825,14 @@ def evolve_interactions(state, config):
             k1 = np.squeeze(np.where(smas==a1))+0
             k2 = np.squeeze(np.where(smas==a2))+0
 
-            if isinstance(k1, np.ndarray):
-                k1=k1[0]
-            if isinstance(k2, np.ndarray):
-                k2=k2[0]
+            k1 = int(np.atleast_1d(k1)[0])
+            k2 = int(np.atleast_1d(k2)[0])
+
+            if k1 == k2:
+                candidates = np.where(smas == a2)[0]
+                k2 = int(candidates[1]) if len(candidates) > 1 else None
+                if k2 is None:
+                    continue
 
             m1 = pairs[k1][1]; s1 = pairs[k1][2]; g1 = pairs[k1][3]; h1 = pairs[k1][4]
             m2 = pairs[k2][1]; s2 = pairs[k2][2]; g2 = pairs[k2][3]; h2 = pairs[k2][4]

--- a/rapster/cluster_evolution.py
+++ b/rapster/cluster_evolution.py
@@ -854,6 +854,7 @@ def evolve_interactions(state, config):
 
                 k_tdeBHstar = 1
                 seed, t, z, k_tdeBHstar, N_tdeBHstar, tde_type, m_avg, m_star, R_star, m1, s1, g1, h1, v_star, vBH, tdes, binaries, pairs, f_accreted, EoS = BH_TidalDisruptions(seed, t, z, k_tdeBHstar, N_tdeBHstar, tde_type, m_avg, m_star, R_star, np.array([m1]), np.array([s1]), np.array([g1]), np.array([h1]), v_star, vBH, tdes, binaries, pairs, f_accreted, EoS)
+                m1, s1, g1, h1 = float(m1[0]), float(s1[0]), float(g1[0]), float(h1[0])
 
             if np.random.rand() < p2_TDE:
                 # then TDE-2 occurs:
@@ -865,6 +866,7 @@ def evolve_interactions(state, config):
 
                 k_tdeBHstar = 1
                 seed, t, z, k_tdeBHstar, N_tdeBHstar, tde_type, m_avg, m_star, R_star, m2, s2, g2, h2, v_star, vBH, tdes, binaries, pairs, f_accreted, EoS = BH_TidalDisruptions(seed, t, z, k_tdeBHstar, N_tdeBHstar, tde_type, m_avg, m_star, R_star, np.array([m2]), np.array([s2]), np.array([g2]), np.array([h2]), v_star, vBH, tdes, binaries, pairs, f_accreted, EoS)
+                m2, s2, g2, h2 = float(m2[0]), float(s2[0]), float(g2[0]), float(h2[0])
 
             # the following exchange happens:
             # BH-star + BH-star -> BH-BH + star' + star'

--- a/rapster/compact_accretion.py
+++ b/rapster/compact_accretion.py
@@ -30,7 +30,7 @@ G    = 6.674e-11  # m^3 kg^-1 s^-2
 Msun_to_km = G * Msun / c**2 / km    # about 1.477 km / M_sun  (= G*Msun/c^2 in km)
 
 # Thorne (1974) spin limit: radiation captured by the BH prevents chi=1
-THORNE_LIMIT = 0.998
+THORNE_LIMIT = THORNE_SPIN_LIMIT
 
 # ---------------------------------------------------------------------------
 # EOS tables  (mass in M_sun, radius in km)

--- a/rapster/constants.py
+++ b/rapster/constants.py
@@ -126,6 +126,9 @@ neutron_star_mass = M_Chandrasekhar
 # white dwarf mass:
 white_dwarf_mass = 0.60
 
+# Thorne maximum spin limit:
+THORNE_SPIN_LIMIT = 0.998
+
 evolution_keys = [
     'seed', 't', 'z', 'dt', 'm_avg', 'M_cl', 'r_h', 'R_gal', 'v_gal', 't_rh', 't_rhBH', 'n_star', 'N_BH', 'mBH_avg', 'mBH_max', 'r_hBH', 'r_cBH', 'S', 'xi', 'psi', 'psi_BH', 't_3bb', 't_2cap', 'k_3bb', 'k_2cap', 'N_me', 'N_BBH', 'N_meRe', 
     'N_meEj', 'v_star', 'v_BH', 'n_hBH', 'n_cBH', 'n_aBH', 'N_3bb', 'N_2cap', 'N_3cap', 'N_BHej', 'N_BBHej', 'N_dis', 'N_ex', 't_bb', 'N_bb', 'N_meFi', 'N_me2b', 't_ex1', 't_ex2', 'k_ex1', 'k_ex2', 'N_ex1', 'N_ex2', 'N_BHstar', 

--- a/rapster/exchanges.py
+++ b/rapster/exchanges.py
@@ -61,9 +61,8 @@ def StarStar_to_BHstar(seed, t, z, k_ex1, N_ex1, m_avg, mBH, sBH, gBH, hBH, ab, 
             
             k = np.squeeze(np.where(mBH==m))+0
             
-            if isinstance(k, np.ndarray):
-                k=k[0]
-                
+            k = int(np.atleast_1d(k)[0])
+            
             s = sBH[k]
             g = gBH[k]
             h = hBH[k]
@@ -72,8 +71,7 @@ def StarStar_to_BHstar(seed, t, z, k_ex1, N_ex1, m_avg, mBH, sBH, gBH, hBH, ab, 
                 
             kss = np.squeeze(np.where(ab==a))+0
             
-            if isinstance(kss, np.ndarray):
-                kss=kss[0]
+            kss = int(np.atleast_1d(kss)[0])
 
             # delete star-star:
             ab = np.delete(ab, kss)
@@ -134,8 +132,7 @@ def BHstar_to_BBH(seed, t, z, k_ex2, N_ex2, m_avg, mBH, sBH, gBH, hBH, pairs, bi
             # location of the sampled BH:
             k2 = np.squeeze(np.where(mBH==m2))+0
             
-            if isinstance(k2, np.ndarray):
-                k2=k2[0]
+            k2 = int(np.atleast_1d(k2)[0])
                 
             s2 = sBH[k2] # spin of the second BH
             g2 = gBH[k2] # generation of the second BH
@@ -146,8 +143,7 @@ def BHstar_to_BBH(seed, t, z, k_ex2, N_ex2, m_avg, mBH, sBH, gBH, hBH, pairs, bi
             
             kp = np.squeeze(np.where(pairs[:, 0]==ap))+0
 
-            if isinstance(kp, np.ndarray):
-                kp=kp[0]
+            kp = int(np.atleast_1d(kp)[0])
                 
             m1 = pairs[kp][1]
             s1 = pairs[kp][2]

--- a/rapster/functions.py
+++ b/rapster/functions.py
@@ -318,6 +318,7 @@ def X_isco(x, s):
     s: 1 for prograde and -1 for retrograde orbits.
     """
     
+    x = np.clip(x, 0.0, THORNE_SPIN_LIMIT)
     Z1 = 1 + (1 - x**2)**(1/3)*((1+x)**(1/3) + (1-x)**(1/3))
     Z2 = np.sqrt(3*x**2 + Z1**2)
     XX = 3 + Z2 - s*np.sqrt((3-Z1)*(3+Z1+2*Z2))

--- a/rapster/three_body_binary.py
+++ b/rapster/three_body_binary.py
@@ -96,11 +96,21 @@ def three_body_binary(t, z, k_3bb, mBH_avg, binaries, mBH, sBH, gBH, hBH, vBH, N
             k1 = np.squeeze(np.where(mBH==m1))+0
             k2 = np.squeeze(np.where(mBH==m2))+0
             
-            if isinstance(k1, np.ndarray):
-                k1 = k1[0]
-            if isinstance(k2, np.ndarray):
-                k2 = k2[0]
-                
+            #if isinstance(k1, np.ndarray):
+            #    k1 = k1[0]
+            #if isinstance(k2, np.ndarray):
+            #    k2 = k2[0]
+            
+            k1 = int(np.atleast_1d(k1)[0])
+            k2 = int(np.atleast_1d(k2)[0])
+            
+            if k1 == k2:
+                # find next available index for k2
+                candidates = np.where(mBH == m2)[0]
+                k2 = int(candidates[1]) if len(candidates) > 1 else None
+                if k2 is None:
+                    continue  # skip this 3bb formation, can't find two distinct BHs
+
             # initial hardness of newly formed 3bb:
             eta = sample_hardness()
             

--- a/rapster/three_body_binary.py
+++ b/rapster/three_body_binary.py
@@ -96,11 +96,6 @@ def three_body_binary(t, z, k_3bb, mBH_avg, binaries, mBH, sBH, gBH, hBH, vBH, N
             k1 = np.squeeze(np.where(mBH==m1))+0
             k2 = np.squeeze(np.where(mBH==m2))+0
             
-            #if isinstance(k1, np.ndarray):
-            #    k1 = k1[0]
-            #if isinstance(k2, np.ndarray):
-            #    k2 = k2[0]
-            
             k1 = int(np.atleast_1d(k1)[0])
             k2 = int(np.atleast_1d(k2)[0])
             

--- a/rapster/tidal_disruptions.py
+++ b/rapster/tidal_disruptions.py
@@ -66,9 +66,8 @@ def BH_TidalDisruptions(seed, t, z, k_tde, N_tde, tde_type, m_avg, m_star, R_sta
             # find index location of that BH mass:
             k = np.squeeze(np.where(mBH==m))+0
             
-            if isinstance(k, np.ndarray):
-                k=k[0]
-                
+            k = int(np.atleast_1d(k)[0])
+            
             s = sBH[k] # get BH's (dimensionless) spin
             g = gBH[k] # get BH's generation
             h = hBH[k] # get BH's tdes count

--- a/rapster/triples.py
+++ b/rapster/triples.py
@@ -126,9 +126,10 @@ def evolve_triples(seed, t, z, zCl_form, triples, binaries, mBH, sBH, gBH, hBH, 
                 # effective spin parameter:
                 s_eff = (m0 * s0 * np.cos(theta0) + m1 * s1 * np.cos(theta1)) / (m0 + m1)
                 
-                # append merger:
-                mergers = np.append(mergers, [[seed, ind_in, 4, a_in, eMAX, m0, m1, s0, s1, g0, g1, theta0, theta1, dPhi, t_form_in, z_form_in, t_merge,
-                                               redshift(lookback(zCl_form) - t_merge), m_rem, s_rem, g_rem, vGW_kick, s_eff, q, 2*v_star, h0, h1]], axis=0)
+                if t_merge < lookback(zCl_form): # check merger happens by redshift z=0 (today):
+                    # append merger:
+                    mergers = np.append(mergers, [[seed, ind_in, 4, a_in, eMAX, m0, m1, s0, s1, g0, g1, theta0, theta1, dPhi, t_form_in, z_form_in, t_merge,
+                                                   redshift(lookback(zCl_form) - t_merge), m_rem, s_rem, g_rem, vGW_kick, s_eff, q, 2*v_star, h0, h1]], axis=0)
                 
                 triples = np.delete(triples, i, axis=0)
 

--- a/rapster/two_body_capture.py
+++ b/rapster/two_body_capture.py
@@ -99,11 +99,15 @@ def two_body_capture(seed, t, dt, z, zCl_form, k_2cap, mBH_avg, binaries, mBH, s
             # find index locations of the sampled BHs:
             k1 = np.squeeze(np.where(mBH==m1))+0
             k2 = np.squeeze(np.where(mBH==m2))+0
-            
-            if isinstance(k1, np.ndarray):
-                k1=k1[0]
-            if isinstance(k2, np.ndarray):
-                k2=k2[0]
+
+            k1 = int(np.atleast_1d(k1)[0])
+            k2 = int(np.atleast_1d(k2)[0])
+
+            if k1 == k2:
+                candidates = np.where(mBH == m2)[0]
+                k2 = int(candidates[1]) if len(candidates) > 1 else None
+                if k2 is None:
+                    continue
                 
             s1 = sBH[k1]; g1 = gBH[k1]; h1 = hBH[k1]
             s2 = sBH[k2]; g2 = gBH[k2]; h2 = hBH[k2]


### PR DESCRIPTION
1. Spin exceeding physical limit in ISCO calculation (functions.py)
TDE accretion events could drive the BH dimensionless spin parameter above 1, causing
(1 - x**2)**(1/3) to receive a negative argument and produce NaN. Fixed by clamping
spin to [0, THORNE_SPIN_LIMIT] (= 0.998, defined in constants.py) before the ISCO
formula is evaluated. The spin growth integrator in dxdM was already capped but the
ISCO evaluator was not.

2. Fragile array index extraction across multiple files
Files affected: three_body_binary.py, two_body_capture.py, exchanges.py,
cluster_evolution.py, tidal_disruptions.py, binary_evolution.py
Index lookups of the form:
pythonk = np.squeeze(np.where(array == value)) + 0
if isinstance(k, np.ndarray):
    k = k[0]
are unreliable: when np.squeeze produces a 0-dimensional array (single match),
isinstance correctly identifies it as an ndarray but k[0] raises an IndexError
on a 0-d array. Replaced all occurrences with the robust pattern:
pythonk = int(np.atleast_1d(k)[0])
which handles 0-d arrays, 1-d arrays, and plain Python ints uniformly.
Affected locations:

three_body_binary.py: index extraction for k1, k2
two_body_capture.py: index extraction for k1, k2
exchanges.py: index extraction for k, kss, k2, kp (4 locations)
cluster_evolution.py: index extraction for k1, k2 in BH-star+BH-star interactions
tidal_disruptions.py: index extraction for k
binary_evolution.py: index extraction for k2, k3 (2 locations)


3. Duplicate BH index when two BHs share the same mass
Files affected: three_body_binary.py, two_body_capture.py, cluster_evolution.py
When mBH contains duplicate mass values (common in large populations), searching by
value with np.where(mBH == m) can return the same index for both k1 and k2,
causing the same BH to be used twice. This silently produced unphysical binaries and
incorrect BH accounting (deleting only one BH instead of two). Fixed by adding a
k1 == k2 guard that searches for an alternative second index, and skips the formation
event with continue if none is available:
pythonif k1 == k2:
    candidates = np.where(mBH == m2)[0]
    k2 = int(candidates[1]) if len(candidates) > 1 else None
    if k2 is None:
        continue

4. TDE return values used as arrays instead of scalars (cluster_evolution.py)
In the BH-star+BH-star interaction block, after calling BH_TidalDisruptions with
single-element input arrays, the returned mBH, sBH, gBH, hBH are still arrays.
The unpacked variables m1, s1, g1, h1 (and m2, s2, g2, h2) were
subsequently used as scalars in comparisons and in the np.append call constructing
the new binary row, producing an inhomogeneous array shape and a ValueError crash.
Fixed by explicitly unpacking with float(m[0]) after each TDE call:
pythonm1, s1, g1, h1 = float(m1[0]), float(s1[0]), float(g1[0]), float(h1[0])

5. ZLK merger time exceeding the age of the universe (triples.py)
When t_ZLK is very long, t_merge = t + t_ZLK can exceed lookback(zCl_form) (the
total available simulation time). Previously this was passed to
redshift(lookback(zCl_form) - t_merge), which received a negative argument and
silently returned z = 0, recording a physically wrong merger redshift. Fixed by
skipping the append to the mergers array when t_merge >= lookback(zCl_form).
Counters (N_me, N_ZLK) and remnant handling are unaffected — only the output
record is suppressed.

Notes

All fixes are backward compatible and do not affect results for standard cluster parameters.
The fix for issue 3 may cause a small number of 3bb/2-capture events to be skipped
(continue) when duplicate BH masses are present and no alternative index exists;
this is physically correct behavior (the formation simply does not proceed).
Tested against the default parameter set; results match the reference output in
Example/Results_Test/.