### PR TITLE
timing optimization 

### DIFF
--- a/rapster/binary_evolution.py
+++ b/rapster/binary_evolution.py
@@ -164,7 +164,7 @@ def evolve_BBHs(seed, t, z, dt, zCl_form, binaries, hardening, mergers, mBH, sBH
                     dt_local = t_BBH_BBH
                     type_int = 3
                     
-                hardening = np.append(hardening, [[t, dt, t_local, dt_local, ind, a, e, m1, m2, q, condition, Nex]], axis=0)
+                hardening.append([t, dt, t_local, dt_local, ind, a, e, m1, m2, q, condition, Nex])
                 N_hardening+=1
                 
                 if condition>0:
@@ -715,7 +715,7 @@ def evolve_BBHs(seed, t, z, dt, zCl_form, binaries, hardening, mergers, mBH, sBH
                     hardening[i][10]=condition
                     break
 
-            hardening = np.append(hardening, [[t, dt, t_local, dt_local, ind, a, e, m1, m2, q, condition, Nex]], axis=0)
+            hardening.append([t, dt, t_local, dt_local, ind, a, e, m1, m2, q, condition, Nex])
             N_hardening+=1
             i+=1
             

--- a/rapster/cluster_evolution.py
+++ b/rapster/cluster_evolution.py
@@ -278,8 +278,8 @@ def initialize_cluster(config):
     pairs = np.zeros(shape=(1, 5))
     triples = np.zeros(shape=(1, 24))
     mergers = np.zeros(shape=(1, 27))
-    evolution = np.zeros(shape=(1, 70))
-    hardening = np.zeros(shape=(1, 12))
+    evolution = [[0.0] * 70]   # list-accumulated (one placeholder row); -> array at write_output
+    hardening = [[0.0] * 12]   # list-accumulated (one placeholder row); -> array at write_output
     tdes = np.zeros(shape=(1, 18))
 
     configure_kick_model(config['recoil_kick_model'])
@@ -1065,12 +1065,12 @@ def record_evolution(state):
     N_tdeBBHstar = state['N_tdeBBHstar']
 
     # append a row of 70 time-dependent quantities to the evolution array:
-    state['evolution'] = np.append(state['evolution'], [[seed, t, z, dt, m_avg, Mcl, rh, R_gal, v_gal, t_rlx, tBH_rlx, n_star, N_BH, mBH_avg, mBH_max, rh_BH, rc_BH, S,
+    state['evolution'].append([seed, t, z, dt, m_avg, Mcl, rh, R_gal, v_gal, t_rlx, tBH_rlx, n_star, N_BH, mBH_avg, mBH_max, rh_BH, rc_BH, S,
                                        xi, psi, psi_BH, t_3bb, t_2cap, k_3bb, k_2cap, N_me, N_BBH, N_meRe, N_meEj, v_star, vBH,
                                        nh_BH, nc_BH, na_BH, N_3bb, N_2cap, N_3cap, N_BHej, N_BBHej, N_dis, N_ex, t_bb, N_bb,
                                        N_meFi, N_me2b, t_ex1, t_ex2, k_ex1, k_ex2, N_ex1, N_ex2, N_BHstar, t_pp, k_pp, N_pp, 2*v_star,
                                        2*vBH, N_Triples, N_ZLK, N_WD, v_WD, k_tdeBHWD, N_tdeBHWD, dN_WDformdt, dN_WDevdt, dN_tdeBHWDdt, k_tdeBHstar,
-                                       dN_tdeBHstardt, N_tdeBHstar, N_tdeBBHstar]], axis=0)
+                                       dN_tdeBHstardt, N_tdeBHstar, N_tdeBBHstar])
 
 def compute_external_params(state, config):
     """Compute external/environmental parameters for the cluster.
@@ -1260,8 +1260,8 @@ def write_output(state, config):
         config (dict): Configuration dictionary.
     """
     mergers = np.delete(state['mergers'], 0, axis=0)
-    evolution = np.delete(state['evolution'], 0, axis=0)
-    hardening = np.delete(state['hardening'], 0, axis=0)
+    evolution = np.array(state['evolution'], dtype=float)[1:]   # list -> array, drop placeholder row
+    hardening = np.array(state['hardening'], dtype=float)[1:]   # list -> array, drop placeholder row
     tdes = np.delete(state['tdes'], 0, axis=0)
 
     CURRENT_WORKING_DIR = os.getcwd()

--- a/rapster/cluster_evolution.py
+++ b/rapster/cluster_evolution.py
@@ -959,7 +959,7 @@ def evolve_tdes(state, config):
     N_strs = Mcl/m_avg
 
     # WD formation rate (/Myr):
-    dN_WDformdt = N_strs/t/2.5 * Kroupa_norm*IMF_kroupa(np.array([(solar_life/t)**(1/2.5)]))[0] * (solar_life/t)**(1/2.5) if t>t_WN else 0.0
+    dN_WDformdt = N_strs/t/2.5 * Kroupa_norm*IMF_kroupa((solar_life/t)**(1/2.5)) * (solar_life/t)**(1/2.5) if t>t_WN else 0.0
 
     # WD evaporation rate (/Myr):
     dN_WDevdt = xi_e*N_WD/t_rlx if N_WD>0 else 0.0

--- a/rapster/compact_accretion.py
+++ b/rapster/compact_accretion.py
@@ -490,30 +490,21 @@ def J_isco(M, NS=True, R=None, f=None, chi=None, prograde=True):
 #   = km^2 
 # ---------------------------------------------------------------------------
 
-def evolve(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
+def evolve_spin_during_accretion(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
     """
     Evolve compact object spin via disk accretion.
 
-    The object starts as a NS (NS=True) or BH (NS=False).  If NS=True and
-    the mass exceeds M_max_rot the evolution automatically switches to the
-    Bardeen (1970) BH regime.
+    The object starts as a NS (NS=True) or BH (NS=False).  If NS=True and the
+    mass exceeds M_max_rot the evolution switches to the Bardeen (1970) BH regime.
 
-    Parameters
-    ----------
-    Mi  : float - initial mass [M_sun]
-    Mf  : float - final mass [M_sun]
-    NS  : bool  - True if the initial object is a neutron star
-    f   : float - initial spin frequency [Hz]  (provide f or chi, not both)
-    chi : float - initial dimensionless spin    (default 0.0)
-    dM       : float - mass step [M_sun] (sign set automatically from Mf-Mi)
-    eos      : str   - 'APR' or 'AU', required if NS=True
-    prograde : bool  - True for prograde accretion (spin-up), False for retrograde
-                       (spin-down). When retrograde drives chi to 0 the orbit
-                       automatically flips to prograde, matching Bardeen (1970).
+    Returns a dict with keys NS, M, J, R, f, chi, fK, chiK; only the FINAL
+    per-step state is stored (as length-1 arrays), which is all the callers use.
 
-    Returns
-    -------
-    dict with keys: NS, M, J, R, f, chi, fK, chiK
+    Implementation notes (performance, physics unchanged):
+      - math.sqrt (Python-float, no numpy scalar dispatch) for the sqrt calls,
+      - the BH-branch isco/f_from_chi math is inlined into the loop, and
+      - the BH ISCO radius is computed once per step (shared by E and J).
+    The rarer NS branch uses the helper functions (E_isco/J_isco/f_from_chi/...).
     """
     # --- input validation ---
     if f is not None and chi != 0.0:
@@ -524,145 +515,6 @@ def evolve(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
         raise ValueError("NS=True requires an EOS: 'APR' or 'AU'.")
 
     # --- EOS selection ---
-    if NS:
-        if eos == 'APR':
-            Radius    = Radius_APR
-            M_TOV     = M_APR_TOV
-            M_max_rot = M_APR_max_rot
-        elif eos == 'AU':
-            Radius    = Radius_AU
-            M_TOV     = M_AU_TOV
-            M_max_rot = M_AU_max_rot
-        else:
-            raise ValueError(f"Unknown EOS '{eos}'. Choose 'APR' or 'AU'.")
-        if Mi > M_max_rot:
-            raise ValueError(
-                f"Mi={Mi:.3f} M_sun exceeds M_max_rot={M_max_rot:.3f} M_sun "
-                f"for EOS={eos}. Use NS=False to treat as a BH."
-            )
-        R_TOV = Radius(M_TOV)   # freeze radius above M_TOV
-    else:
-        Radius    = None
-        M_TOV     = None
-        M_max_rot = -np.inf     # always in BH phase
-        R_TOV     = None
-
-    # --- dM sign follows direction of evolution ---
-    dM = abs(dM) * np.sign(Mf - Mi)
-
-    # --- initialise ---
-    M  = float(Mi)
-    Mg = geom_mass(M)
-
-    if NS:
-        R = Radius(min(M, M_TOV))
-        if f is not None:
-            chi = chi_from_frequency(M, R, f)
-        chi = float(min(max(chi, 0.0), THORNE_LIMIT))
-    else:
-        chi = float(min(max(chi, 0.0), THORNE_LIMIT))
-        R   = Mg * (1.0 + np.sqrt(1.0 - chi**2))   # outer horizon radius
-
-    J = chi * Mg**2   # geometric angular momentum [km^2]
-
-    # --- output storage ---
-    NS_arr, M_arr, J_arr, R_arr      = [], [], [], []
-    f_arr, chi_arr, fK_arr, chiK_arr = [], [], [], []
-
-    def not_done(m):
-        return m > Mf if dM < 0 else m < Mf
-
-    # --- orbit direction (mutable: flips to prograde once chi reaches 0) ---
-    # chi is always >= 0 (magnitude); prograde_now tracks direction.
-    # When retrograde accretion drives chi to 0 the disk flips prograde,
-    # matching Bardeen (1970) and the standalone evolve_spin_RK4.
-    prograde_now = prograde
-
-    # --- main loop ---
-    while not_done(M):
-
-        is_NS = NS and (M < M_max_rot)
-
-        Mg  = geom_mass(M)
-        chi = float(min(max(J / Mg**2, 0.0), THORNE_LIMIT))
-
-        if is_NS:
-            # freeze radius in supramassive regime (M_TOV < M < M_max_rot)
-            R    = Radius(min(M, M_TOV))
-            f    = f_from_chi(M, chi, R=R, NS=True)
-            fK   = f_kepler(M, NS=True, R=R)
-            chiK = chi_kepler(M, NS=True, R=R)
-        else:
-            # BH: R = outer Kerr horizon
-            R    = Mg * (1.0 + np.sqrt(1.0 - chi**2))
-            f    = f_from_chi(M, chi, NS=False)
-            fK   = f_kepler(M, NS=False)
-            chiK = chi_kepler(M, NS=False)
-
-        # --- store current state ---
-        NS_arr.append(is_NS)
-        M_arr.append(M)
-        J_arr.append(J)
-        R_arr.append(R)
-        f_arr.append(f)
-        chi_arr.append(chi)
-        fK_arr.append(fK)
-        chiK_arr.append(chiK)
-
-        # --- advance ---
-        if f < fK:
-            if is_NS:
-                e = E_isco(M, NS=True,  R=R, f=f, prograde=prograde_now)
-                j = J_isco(M, NS=True,  R=R, f=f, prograde=prograde_now)
-            else:
-                e = E_isco(M, NS=False, chi=chi, prograde=prograde_now)
-                j = J_isco(M, NS=False, chi=chi, prograde=prograde_now)
-
-            # j < 0 for retrograde: J decreases. Clamp at 0 and flip to prograde.
-            J_new = J + (j / e) * dM * Msun_to_km
-            if J_new < 0.0 and not prograde_now:
-                J_new        = 0.0
-                prograde_now = True
-            J  = J_new
-            M += dM
-        else:
-            # at spin limit: clamp J to Kepler/Thorne value, advance M
-            M  += dM
-            Mg  = geom_mass(M)
-            J   = chiK * Mg**2
-
-    return {
-        'NS'  : np.array(NS_arr),
-        'M'   : np.array(M_arr),
-        'J'   : np.array(J_arr),
-        'R'   : np.array(R_arr),
-        'f'   : np.array(f_arr),
-        'chi' : np.array(chi_arr),
-        'fK'  : np.array(fK_arr),
-        'chiK': np.array(chiK_arr),
-    }
-
-def evolve_v2(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
-    """
-    Faster, behavior-identical reimplementation of evolve().
-
-    Same physics and (bit-)identical outputs as evolve(); optimized by:
-      - using math.sqrt (Python-float, no numpy scalar dispatch) for the
-        correctly-rounded sqrt calls,
-      - inlining the BH-branch isco/f_from_chi math into the loop, and
-      - computing the BH ISCO radius once per step (shared by E and J) instead
-        of twice.
-    The rarer NS branch reuses the original helper functions (still correct).
-    """
-    # --- input validation (identical to evolve) ---
-    if f is not None and chi != 0.0:
-        raise ValueError("Provide either f or chi as initial condition, not both.")
-    if Mi == Mf:
-        raise ValueError("Mi and Mf must differ.")
-    if NS and eos is None:
-        raise ValueError("NS=True requires an EOS: 'APR' or 'AU'.")
-
-    # --- EOS selection (identical to evolve) ---
     if NS:
         if eos == 'APR':
             Radius    = Radius_APR
@@ -690,7 +542,7 @@ def evolve_v2(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
     step = abs(dM)
     dM = step if (Mf - Mi) > 0 else (-step if (Mf - Mi) < 0 else 0.0)
 
-    # --- initialise (identical to evolve) ---
+    # --- initialise ---
     M  = float(Mi)
     Mg = M * Msun_to_km
 

--- a/rapster/compact_accretion.py
+++ b/rapster/compact_accretion.py
@@ -705,13 +705,11 @@ def evolve_v2(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
 
     J = chi * Mg**2
 
-    NS_arr, M_arr, J_arr, R_arr      = [], [], [], []
-    f_arr, chi_arr, fK_arr, chiK_arr = [], [], [], []
-
     def not_done(m):
         return m > Mf if dM < 0 else m < Mf
 
     prograde_now = prograde
+    last = None   # only the final per-step state is needed by callers (evo[...][-1])
 
     while not_done(M):
 
@@ -735,8 +733,7 @@ def evolve_v2(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
                                           * (1.0 + math.sqrt(1.0 - THORNE_LIMIT**2)))
             chiK = THORNE_LIMIT
 
-        NS_arr.append(is_NS); M_arr.append(M); J_arr.append(J); R_arr.append(R)
-        f_arr.append(f); chi_arr.append(chi); fK_arr.append(fK); chiK_arr.append(chiK)
+        last = (is_NS, M, J, R, f, chi, fK, chiK)   # current pre-advance state
 
         if f < fK:
             if is_NS:
@@ -767,15 +764,18 @@ def evolve_v2(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
             Mg  = M * Msun_to_km
             J   = chiK * Mg**2
 
+    # only the final per-step state is returned (as length-1 arrays so callers'
+    # evo[key][-1] indexing still works); intermediate history is not stored.
+    is_NS, M, J, R, f, chi, fK, chiK = last
     return {
-        'NS'  : np.array(NS_arr),
-        'M'   : np.array(M_arr),
-        'J'   : np.array(J_arr),
-        'R'   : np.array(R_arr),
-        'f'   : np.array(f_arr),
-        'chi' : np.array(chi_arr),
-        'fK'  : np.array(fK_arr),
-        'chiK': np.array(chiK_arr),
+        'NS'  : np.array([is_NS]),
+        'M'   : np.array([M]),
+        'J'   : np.array([J]),
+        'R'   : np.array([R]),
+        'f'   : np.array([f]),
+        'chi' : np.array([chi]),
+        'fK'  : np.array([fK]),
+        'chiK': np.array([chiK]),
     }
 
 # End of file.

--- a/rapster/compact_accretion.py
+++ b/rapster/compact_accretion.py
@@ -16,6 +16,8 @@
 
 '''
 
+import math
+
 from .constants import *
 
 # ---------------------------------------------------------------------------
@@ -627,6 +629,142 @@ def evolve(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
             # at spin limit: clamp J to Kepler/Thorne value, advance M
             M  += dM
             Mg  = geom_mass(M)
+            J   = chiK * Mg**2
+
+    return {
+        'NS'  : np.array(NS_arr),
+        'M'   : np.array(M_arr),
+        'J'   : np.array(J_arr),
+        'R'   : np.array(R_arr),
+        'f'   : np.array(f_arr),
+        'chi' : np.array(chi_arr),
+        'fK'  : np.array(fK_arr),
+        'chiK': np.array(chiK_arr),
+    }
+
+def evolve_v2(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
+    """
+    Faster, behavior-identical reimplementation of evolve().
+
+    Same physics and (bit-)identical outputs as evolve(); optimized by:
+      - using math.sqrt (Python-float, no numpy scalar dispatch) for the
+        correctly-rounded sqrt calls,
+      - inlining the BH-branch isco/f_from_chi math into the loop, and
+      - computing the BH ISCO radius once per step (shared by E and J) instead
+        of twice.
+    The rarer NS branch reuses the original helper functions (still correct).
+    """
+    # --- input validation (identical to evolve) ---
+    if f is not None and chi != 0.0:
+        raise ValueError("Provide either f or chi as initial condition, not both.")
+    if Mi == Mf:
+        raise ValueError("Mi and Mf must differ.")
+    if NS and eos is None:
+        raise ValueError("NS=True requires an EOS: 'APR' or 'AU'.")
+
+    # --- EOS selection (identical to evolve) ---
+    if NS:
+        if eos == 'APR':
+            Radius    = Radius_APR
+            M_TOV     = M_APR_TOV
+            M_max_rot = M_APR_max_rot
+        elif eos == 'AU':
+            Radius    = Radius_AU
+            M_TOV     = M_AU_TOV
+            M_max_rot = M_AU_max_rot
+        else:
+            raise ValueError(f"Unknown EOS '{eos}'. Choose 'APR' or 'AU'.")
+        if Mi > M_max_rot:
+            raise ValueError(
+                f"Mi={Mi:.3f} M_sun exceeds M_max_rot={M_max_rot:.3f} M_sun "
+                f"for EOS={eos}. Use NS=False to treat as a BH."
+            )
+        R_TOV = Radius(M_TOV)
+    else:
+        Radius    = None
+        M_TOV     = None
+        M_max_rot = -math.inf
+        R_TOV     = None
+
+    # dM sign follows direction (np.sign identical to this for nonzero) ---
+    step = abs(dM)
+    dM = step if (Mf - Mi) > 0 else (-step if (Mf - Mi) < 0 else 0.0)
+
+    # --- initialise (identical to evolve) ---
+    M  = float(Mi)
+    Mg = M * Msun_to_km
+
+    if NS:
+        R = Radius(min(M, M_TOV))
+        if f is not None:
+            chi = chi_from_frequency(M, R, f)
+        chi = float(min(max(chi, 0.0), THORNE_LIMIT))
+    else:
+        chi = float(min(max(chi, 0.0), THORNE_LIMIT))
+        R   = Mg * (1.0 + math.sqrt(1.0 - chi**2))
+
+    J = chi * Mg**2
+
+    NS_arr, M_arr, J_arr, R_arr      = [], [], [], []
+    f_arr, chi_arr, fK_arr, chiK_arr = [], [], [], []
+
+    def not_done(m):
+        return m > Mf if dM < 0 else m < Mf
+
+    prograde_now = prograde
+
+    while not_done(M):
+
+        is_NS = NS and (M < M_max_rot)
+
+        Mg  = M * Msun_to_km
+        chi = float(min(max(J / Mg**2, 0.0), THORNE_LIMIT))
+
+        if is_NS:
+            # rarer NS path: reuse original (correct) helpers
+            R    = Radius(min(M, M_TOV))
+            f    = f_from_chi(M, chi, R=R, NS=True)
+            fK   = f_kepler(M, NS=True, R=R)
+            chiK = chi_kepler(M, NS=True, R=R)
+        else:
+            # BH path, inlined with math.sqrt (mirrors f_from_chi / R_ISCO / E_isco / J_isco)
+            R    = Mg * (1.0 + math.sqrt(1.0 - chi**2))
+            M_SI = M * Msun
+            f    = c**3 * chi / (4.0 * math.pi * G * M_SI * (1.0 + math.sqrt(1.0 - chi**2)))
+            fK   = c**3 * THORNE_LIMIT / (4.0 * math.pi * G * M_SI
+                                          * (1.0 + math.sqrt(1.0 - THORNE_LIMIT**2)))
+            chiK = THORNE_LIMIT
+
+        NS_arr.append(is_NS); M_arr.append(M); J_arr.append(J); R_arr.append(R)
+        f_arr.append(f); chi_arr.append(chi); fK_arr.append(fK); chiK_arr.append(chiK)
+
+        if f < fK:
+            if is_NS:
+                e = E_isco(M, NS=True, R=R, f=f, prograde=prograde_now)
+                j = J_isco(M, NS=True, R=R, f=f, prograde=prograde_now)
+            else:
+                # BH: R_ISCO computed once, shared by E~ and J~ (mirrors E_isco/J_isco, NS=False)
+                sign = +1.0 if prograde_now else -1.0
+                Z1   = 1.0 + (1.0 - chi**2)**(1.0/3.0) * (
+                           (1.0 + chi)**(1.0/3.0) + (1.0 - chi)**(1.0/3.0))
+                Z2   = math.sqrt(3.0 * chi**2 + Z1**2)
+                r    = Mg * (3.0 + Z2 - sign * math.sqrt((3.0 - Z1) * (3.0 + Z1 + 2.0*Z2)))
+                rt   = r / Mg
+                e    = ((1.0 - 2.0/rt + sign*chi/rt**1.5)
+                        / math.sqrt(1.0 - 3.0/rt + 2.0*sign*chi/rt**1.5))
+                num   = sign * (rt**2 - 2.0*sign*chi*rt**0.5 + chi**2)
+                denom = rt**0.75 * math.sqrt(rt**1.5 - 3.0*rt**0.5 + 2.0*sign*chi)
+                j    = Mg * num / denom
+
+            J_new = J + (j / e) * dM * Msun_to_km
+            if J_new < 0.0 and not prograde_now:
+                J_new        = 0.0
+                prograde_now = True
+            J  = J_new
+            M += dM
+        else:
+            M  += dM
+            Mg  = M * Msun_to_km
             J   = chiK * Mg**2
 
     return {

--- a/rapster/compact_accretion.py
+++ b/rapster/compact_accretion.py
@@ -192,7 +192,7 @@ def f_from_chi(M, chi, R=None, NS=True):
         I_SI = moment_of_inertia(M, R) * Msun * km**2
         return chi * G * M_SI**2 / (2.0 * np.pi * c * I_SI)
     else:
-        chi = np.clip(chi, 0.0, THORNE_LIMIT)
+        chi = min(max(chi, 0.0), THORNE_LIMIT)
         return c**3 * chi / (4.0 * np.pi * G * M_SI
                              * (1.0 + np.sqrt(1.0 - chi**2)))
 
@@ -238,7 +238,7 @@ def R_ISCO(M, NS=True, R=None, f=None, chi=None, prograde=True):
     else:
         if chi is None:
             raise ValueError("chi must be provided for BH (NS=False).")
-        chi  = np.clip(chi, 0.0, THORNE_LIMIT)
+        chi  = min(max(chi, 0.0), THORNE_LIMIT)
         Mg   = geom_mass(M)
         Z1   = 1.0 + (1.0 - chi**2)**(1.0/3.0) * (
                    (1.0 + chi)**(1.0/3.0) + (1.0 - chi)**(1.0/3.0)
@@ -361,7 +361,7 @@ def _E_J_isco_NS(M, R, f, prograde=True):
 
     # prograde: frame-dragging aids orbit (subtract N^phi)
     # retrograde: frame-dragging opposes orbit (add N^phi)
-    v     = np.clip((Omega_S - sign * Nphi) * r_m / N, 0.0, 0.9999)
+    v     = min(max((Omega_S - sign * Nphi) * r_m / N, 0.0), 0.9999)
     gamma = 1.0 / np.sqrt(1.0 - v**2)
 
     E = (N + Nphi * v * r_m) * gamma                   # dimensionless (always > 0)
@@ -401,7 +401,7 @@ def E_isco(M, NS=True, R=None, f=None, chi=None, prograde=True):
     else:
         if chi is None:
             raise ValueError("chi must be provided for BH (NS=False).")
-        chi  = np.clip(chi, 0.0, 1.0 - 1e-10)
+        chi  = min(max(chi, 0.0), 1.0 - 1e-10)
         Mg   = geom_mass(M)                             # km
         r    = R_ISCO(M, NS=False, chi=chi,
                       prograde=prograde)                 # km
@@ -442,7 +442,7 @@ def J_isco(M, NS=True, R=None, f=None, chi=None, prograde=True):
     else:
         if chi is None:
             raise ValueError("chi must be provided for BH (NS=False).")
-        chi  = np.clip(chi, 0.0, 1.0 - 1e-10)
+        chi  = min(max(chi, 0.0), 1.0 - 1e-10)
         Mg   = geom_mass(M)                             # km
         r    = R_ISCO(M, NS=False, chi=chi,
                       prograde=prograde)                 # km
@@ -556,9 +556,9 @@ def evolve(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
         R = Radius(min(M, M_TOV))
         if f is not None:
             chi = chi_from_frequency(M, R, f)
-        chi = float(np.clip(chi, 0.0, THORNE_LIMIT))
+        chi = float(min(max(chi, 0.0), THORNE_LIMIT))
     else:
-        chi = float(np.clip(chi, 0.0, THORNE_LIMIT))
+        chi = float(min(max(chi, 0.0), THORNE_LIMIT))
         R   = Mg * (1.0 + np.sqrt(1.0 - chi**2))   # outer horizon radius
 
     J = chi * Mg**2   # geometric angular momentum [km^2]
@@ -582,7 +582,7 @@ def evolve(Mi, Mf, NS, f=None, chi=0.0, dM=1e-3, eos='APR', prograde=True):
         is_NS = NS and (M < M_max_rot)
 
         Mg  = geom_mass(M)
-        chi = float(np.clip(J / Mg**2, 0.0, THORNE_LIMIT))
+        chi = float(min(max(J / Mg**2, 0.0), THORNE_LIMIT))
 
         if is_NS:
             # freeze radius in supramassive regime (M_TOV < M < M_max_rot)

--- a/rapster/functions.py
+++ b/rapster/functions.py
@@ -37,8 +37,49 @@ a_BH_vec = loaded_data_xMB['a_BH_vec']
 iota_vec = loaded_data_xMB['iota_vec']
 
 # interpolate redshift-lookback and lookback-redshift relations:
-lookback_interp = interpolate.interp1d(Planck18_lookup_table['z'], Planck18_lookup_table['lookback'])
-redshift_interp = interpolate.interp1d(Planck18_lookup_table['t'], Planck18_lookup_table['redshift'])
+# Build the interpolators once over the Planck18 lookup table; the public
+# wrappers below add a domain check so out-of-range inputs raise a clear error
+# instead of silently extrapolating.
+_lookback_interp = interpolate.interp1d(Planck18_lookup_table['z'], Planck18_lookup_table['lookback'])
+_redshift_interp = interpolate.interp1d(Planck18_lookup_table['t'], Planck18_lookup_table['redshift'])
+
+# tabulated domains (set by the Planck18 lookup table):
+_Z_MIN, _Z_MAX = float(Planck18_lookup_table['z'].min()), float(Planck18_lookup_table['z'].max())
+_T_MIN, _T_MAX = float(Planck18_lookup_table['t'].min()), float(Planck18_lookup_table['t'].max())
+
+
+def lookback_interp(z):
+    """
+    Lookback time [Myr] at redshift z, via interpolation over the Planck18
+    lookup table (fast replacement for lookback()).
+
+    @in z: redshift (scalar or array)
+
+    @out: lookback time [Myr]
+    """
+    if np.any(np.asarray(z) < _Z_MIN) or np.any(np.asarray(z) > _Z_MAX):
+        raise ValueError(
+            f"lookback_interp: redshift z={z} is outside the Planck18 lookup "
+            f"table range z in [{_Z_MIN}, {_Z_MAX}]."
+        )
+    return _lookback_interp(z)
+
+
+def redshift_interp(t):
+    """
+    Redshift at lookback time t [Myr], via interpolation over the Planck18
+    lookup table (fast replacement for redshift()).
+
+    @in t: lookback time [Myr] (scalar or array)
+
+    @out: redshift
+    """
+    if np.any(np.asarray(t) < _T_MIN) or np.any(np.asarray(t) > _T_MAX):
+        raise ValueError(
+            f"redshift_interp: lookback time t={t} Myr is outside the Planck18 "
+            f"lookup table range t in [{_T_MIN}, {_T_MAX}] Myr."
+        )
+    return _redshift_interp(t)
 
 # interpolate auxiliary function:
 x_mb_interp = CloughTocher2DInterpolator(np.c_[a_BH_vec, iota_vec], x_mb_vec)

--- a/rapster/stellar_evolution.py
+++ b/rapster/stellar_evolution.py
@@ -100,6 +100,10 @@ def Mrem_F12d(M, Z):
     M_lowerEdge = 45  # absolute lower edge of the upper mass gap (in solar masses)
     M_upperEdge = 120 # absolute upper edge of the upper mass gap (in solar masses)
     
+    # accept a python list too, by converting it to an array:
+    if isinstance(M, list):
+        M = np.asarray(M, dtype=float)
+
     # check if mass input is an array or not:
     if isinstance(M, np.ndarray): # M is array
         
@@ -112,7 +116,6 @@ def Mrem_F12d(M, Z):
         out = float(out)
     
     return out
-Mrem_F12d = np.vectorize(Mrem_F12d)
 
 def Mrem_F12r(M, Z):
     """
@@ -127,6 +130,10 @@ def Mrem_F12r(M, Z):
     M_lowerEdge = 45  # absolute lower edge of the upper mass gap (in solar masses)
     M_upperEdge = 120 # absolute upper edge of the upper mass gap (in solar masses)
     
+    # accept a python list too, by converting it to an array:
+    if isinstance(M, list):
+        M = np.asarray(M, dtype=float)
+
     # check if mass input is an array or not:
     if isinstance(M, np.ndarray): # M is array
         
@@ -137,9 +144,8 @@ def Mrem_F12r(M, Z):
         out = MremInterpol_F12r((M, Z)) * (np.heaviside(M_lowerEdge - MremInterpol_F12r((M, Z)), 0) \
             + np.heaviside(MremInterpol_F12r((M, Z)) - M_upperEdge, 0))
         out = float(out)
-    
+
     return out
-Mrem_F12r = np.vectorize(Mrem_F12r)
 
 DATA_DIR = os.path.join(BASE_DIR, '..', 'Data', 'MzamsMrem')
 
@@ -189,6 +195,10 @@ def Mrem_SEVNdelayed(M, Z):
     M_lowerEdge = 55  # absolute lower edge of the upper mass gap (in solar masses)
     M_upperEdge = 120 # absolute upper edge of the upper mass gap (in solar masses)
     
+    # accept a python list too, by converting it to an array:
+    if isinstance(M, list):
+        M = np.asarray(M, dtype=float)
+
     # check if mass input is an array or not:
     if isinstance(M, np.ndarray): # M is array
         
@@ -202,7 +212,6 @@ def Mrem_SEVNdelayed(M, Z):
         out = float(out)
 
     return out
-Mrem_SEVNdelayed = np.vectorize(Mrem_SEVNdelayed)
 
 def Mrem_SEVNrapid(M, Z):
     '''
@@ -218,6 +227,10 @@ def Mrem_SEVNrapid(M, Z):
     M_lowerEdge = 55  # absolute lower edge of the upper mass gap (in solar masses)
     M_upperEdge = 120 # absolute upper edge of the upper mass gap (in solar masses)
     
+    # accept a python list too, by converting it to an array:
+    if isinstance(M, list):
+        M = np.asarray(M, dtype=float)
+
     # check if mass input is an array or not:
     if isinstance(M, np.ndarray): # M is array
         
@@ -231,7 +244,6 @@ def Mrem_SEVNrapid(M, Z):
         out = float(out)
 
     return out
-Mrem_SEVNrapid = np.vectorize(Mrem_SEVNrapid)
 
 def M_CO_SSE(M, Z):
     """

--- a/rapster/stellar_evolution.py
+++ b/rapster/stellar_evolution.py
@@ -30,7 +30,6 @@ def IMF_kroupa(m):
 
     m = np.asarray(m, dtype=float)
     scalar_input = (m.ndim == 0)
-    m = np.atleast_1d(m)
 
     # mass boundaries (in solar masses):
     m1 = 0.08
@@ -48,27 +47,24 @@ def IMF_kroupa(m):
     c2 = c1 * m2**a1 / m2**a2
     c3 = c2 * m3**a2 / m3**a3
 
-    out = np.zeros(m.size)
+    # fast scalar path (avoids np.select overhead for the per-element quad calls):
+    if scalar_input:
+        mv = float(m)
+        if   mv <= m1: return mv**a0
+        elif mv <= m2: return c1 * mv**a1
+        elif mv <= m3: return c2 * mv**a2
+        else:          return c3 * mv**a3
 
-    for i in range(0,m.size):
-        
-        if  (m[i] <= m1):
-            
-            out[i] = m[i]**a0
-            
-        elif(m[i] <= m2 and m[i] > m1):
-            
-            out[i] = c1 * m[i]**a1
-            
-        elif(m[i] <= m3 and m[i] > m2):
-            
-            out[i] = c2 * m[i]**a2
-            
-        elif(m[i] >= m3):
-            
-            out[i] = c3 * m[i]**a3
-                    
-    return float(out[0]) if scalar_input else out
+    # vectorized array path (same bin edges as the original loop):
+    conditions = [m <= m1,
+                  (m > m1) & (m <= m2),
+                  (m > m2) & (m <= m3),
+                  m > m3]
+    choices = [m**a0,
+               c1 * m**a1,
+               c2 * m**a2,
+               c3 * m**a3]
+    return np.select(conditions, choices, default=0.0)
 
 N_grid = 700
 M_grid = np.linspace(10, 340, N_grid)

--- a/rapster/tidal_disruptions.py
+++ b/rapster/tidal_disruptions.py
@@ -107,7 +107,7 @@ def BH_TidalDisruptions(seed, t, z, k_tde, N_tde, tde_type, m_avg, m_star, R_sta
             NS = True if m<M_NS_max else False
 
             # evolve spin during disk accretion:
-            evo = evolve_v2(Mi=m, Mf=m+dm, NS=NS, f=None, chi=s, dM=dm/100, eos=EoS, prograde=prograde)
+            evo = evolve_spin_during_accretion(Mi=m, Mf=m+dm, NS=NS, f=None, chi=s, dM=dm/100, eos=EoS, prograde=prograde)
 
             # final spin:
             s_new = evo['chi'][-1]
@@ -189,8 +189,8 @@ def try_BBH_star_disruption(rp, a, m1, m2, s1, s2, g1, g2, h1, h2, m_star, R_sta
         NS2 = True if m2<M_NS_max else False
 
         # evolve the spin of each BH/NS as it accretes its share of the debris:
-        evo1 = evolve_v2(Mi=m1, Mf=m1+dm1, NS=NS1, f=None, chi=s1, dM=dm1/100, eos=EoS, prograde=True)
-        evo2 = evolve_v2(Mi=m2, Mf=m2+dm2, NS=NS2, f=None, chi=s2, dM=dm2/100, eos=EoS, prograde=True)
+        evo1 = evolve_spin_during_accretion(Mi=m1, Mf=m1+dm1, NS=NS1, f=None, chi=s1, dM=dm1/100, eos=EoS, prograde=True)
+        evo2 = evolve_spin_during_accretion(Mi=m2, Mf=m2+dm2, NS=NS2, f=None, chi=s2, dM=dm2/100, eos=EoS, prograde=True)
 
         s1_new = evo1['chi'][-1]
         s2_new = evo2['chi'][-1]
@@ -227,7 +227,7 @@ def try_BBH_star_disruption(rp, a, m1, m2, s1, s2, g1, g2, h1, h2, m_star, R_sta
 
         NS = True if m_d<M_NS_max else False
 
-        evo = evolve_v2(Mi=m_d, Mf=m_d+dm, NS=NS, f=None, chi=s_d, dM=dm/100, eos=EoS, prograde=True)
+        evo = evolve_spin_during_accretion(Mi=m_d, Mf=m_d+dm, NS=NS, f=None, chi=s_d, dM=dm/100, eos=EoS, prograde=True)
         s_new = evo['chi'][-1]
 
         v_rel_tde = np.sqrt(v_star**2*m_avg/m_star + np.mean([m1, m2])/m_star*vBH**2)

--- a/rapster/tidal_disruptions.py
+++ b/rapster/tidal_disruptions.py
@@ -107,7 +107,7 @@ def BH_TidalDisruptions(seed, t, z, k_tde, N_tde, tde_type, m_avg, m_star, R_sta
             NS = True if m<M_NS_max else False
 
             # evolve spin during disk accretion:
-            evo = evolve(Mi=m, Mf=m+dm, NS=NS, f=None, chi=s, dM=dm/100, eos=EoS, prograde=prograde)
+            evo = evolve_v2(Mi=m, Mf=m+dm, NS=NS, f=None, chi=s, dM=dm/100, eos=EoS, prograde=prograde)
 
             # final spin:
             s_new = evo['chi'][-1]
@@ -189,8 +189,8 @@ def try_BBH_star_disruption(rp, a, m1, m2, s1, s2, g1, g2, h1, h2, m_star, R_sta
         NS2 = True if m2<M_NS_max else False
 
         # evolve the spin of each BH/NS as it accretes its share of the debris:
-        evo1 = evolve(Mi=m1, Mf=m1+dm1, NS=NS1, f=None, chi=s1, dM=dm1/100, eos=EoS, prograde=True)
-        evo2 = evolve(Mi=m2, Mf=m2+dm2, NS=NS2, f=None, chi=s2, dM=dm2/100, eos=EoS, prograde=True)
+        evo1 = evolve_v2(Mi=m1, Mf=m1+dm1, NS=NS1, f=None, chi=s1, dM=dm1/100, eos=EoS, prograde=True)
+        evo2 = evolve_v2(Mi=m2, Mf=m2+dm2, NS=NS2, f=None, chi=s2, dM=dm2/100, eos=EoS, prograde=True)
 
         s1_new = evo1['chi'][-1]
         s2_new = evo2['chi'][-1]
@@ -227,7 +227,7 @@ def try_BBH_star_disruption(rp, a, m1, m2, s1, s2, g1, g2, h1, h2, m_star, R_sta
 
         NS = True if m_d<M_NS_max else False
 
-        evo = evolve(Mi=m_d, Mf=m_d+dm, NS=NS, f=None, chi=s_d, dM=dm/100, eos=EoS, prograde=True)
+        evo = evolve_v2(Mi=m_d, Mf=m_d+dm, NS=NS, f=None, chi=s_d, dM=dm/100, eos=EoS, prograde=True)
         s_new = evo['chi'][-1]
 
         v_rel_tde = np.sqrt(v_star**2*m_avg/m_star + np.mean([m1, m2])/m_star*vBH**2)

--- a/rapster/triples.py
+++ b/rapster/triples.py
@@ -127,10 +127,10 @@ def evolve_triples(seed, t, z, zCl_form, triples, binaries, mBH, sBH, gBH, hBH, 
                 # effective spin parameter:
                 s_eff = (m0 * s0 * np.cos(theta0) + m1 * s1 * np.cos(theta1)) / (m0 + m1)
                 
-                if t_merge < lookback(zCl_form): # check merger happens by redshift z=0 (today):
+                if t_merge < lookback_interp(zCl_form): # check merger happens by redshift z=0 (today):
                     # append merger:
                     mergers = np.append(mergers, [[seed, ind_in, 4, a_in, eMAX, m0, m1, s0, s1, g0, g1, theta0, theta1, dPhi, t_form_in, z_form_in, t_merge,
-                                                   redshift(lookback(zCl_form) - t_merge), m_rem, s_rem, g_rem, vGW_kick, s_eff, q, 2*v_star, h0, h1]], axis=0)
+                                                   redshift_interp(lookback_interp(zCl_form) - t_merge), m_rem, s_rem, g_rem, vGW_kick, s_eff, q, 2*v_star, h0, h1]], axis=0)
                 
                 triples = np.delete(triples, i, axis=0)
 
@@ -166,8 +166,8 @@ def evolve_triples(seed, t, z, zCl_form, triples, binaries, mBH, sBH, gBH, hBH, 
                     
                     # append binary;
                     # only append the new outer binary if the merger time is within the simulation horizon:
-                    if t + t_ZLK < lookback(zCl_form):
-                        binaries = np.append(binaries, [[np.random.randint(0, 999999999), 5, a_out, np.sqrt(np.random.rand()), m2, m_rem, s2, s_rem, g2, g_rem, t + t_ZLK, redshift(lookback(zCl_form) - t - t_ZLK), 0, h2, h_rem]], axis=0)
+                    if t + t_ZLK < lookback_interp(zCl_form):
+                        binaries = np.append(binaries, [[np.random.randint(0, 999999999), 5, a_out, np.sqrt(np.random.rand()), m2, m_rem, s2, s_rem, g2, g_rem, t + t_ZLK, redshift_interp(lookback_interp(zCl_form) - t - t_ZLK), 0, h2, h_rem]], axis=0)
                         N_BBH+=1
                         N_meRe+=1
 

--- a/rapster/two_body_capture.py
+++ b/rapster/two_body_capture.py
@@ -184,7 +184,7 @@ def two_body_capture(seed, t, dt, z, zCl_form, k_2cap, mBH_avg, binaries, mBH, s
             N_2cap+=1
             
             # check if binary merges within the current step:
-            if T_GW(m1, m2, sma, eccen) < np.min([dt, lookback(zCl_form) - t]):
+            if T_GW(m1, m2, sma, eccen) < np.min([dt, lookback_interp(zCl_form) - t]):
                 
                 if vGW_kick < 2 * np.sqrt(v_star**2 + vBH**2): # merger remnant retained in cluster
                     
@@ -223,7 +223,7 @@ def two_body_capture(seed, t, dt, z, zCl_form, k_2cap, mBH_avg, binaries, mBH, s
                 
                 # append merger:
                 mergers = np.append(mergers, [[seed, ind, 2, sma, eccen, m1, m2, s1, s2, g1, g2, theta1, theta2, dPhi, t, z, t + T_GW(m1, m2, sma, eccen),
-                                               redshift(lookback(zCl_form) - t - T_GW(m1, m2, sma, eccen)), m_rem, s_rem, g_rem, vGW_kick, s_eff, q, 2*v_star, h1, h2]], axis=0)
+                                               redshift_interp(lookback_interp(zCl_form) - t - T_GW(m1, m2, sma, eccen)), m_rem, s_rem, g_rem, vGW_kick, s_eff, q, 2*v_star, h1, h2]], axis=0)
 
             else:
                 


### PR DESCRIPTION
## Cosmology-inversion hang fix + physics-preserving speedups

  Fixes a hang on dense/massive clusters and ~2× speeds up typical clusters — **all physics byte-identical** (verified on E1, seed 90005100 → 4778 evol / 2655 mergers / 7718 tdes / 63874 hardening unchanged at every step).

  ### Bug fix — cosmology inversion (PR #27)
  `two_body_capture.py` and `triples.py` called the raw, O((z/dz)²) `redshift()` / `lookback()` instead of the interpolated `redshift_interp` / `lookback_interp` that `binary_evolution.py` / `cluster_evolution.py` already use. Each raw call is ~5 s, and dense
  clusters make many per timestep → they effectively hang. Swapped the 6 call sites; hardened the interp helpers with a domain check (raise outside the table range instead of silently extrapolating). Numerically identical (2.879 vs 2.879).
  **Exp-D idx 25304 (densest real timed-out cluster): 3600 s timeout → 37.5 s.**

  ### Performance (each verified bit-identical)
  - `Mrem_*`: drop `np.vectorize`, use the existing `RegularGridInterpolator` array branch (+ list input) → init ~19× faster
  - `IMF_kroupa`: vectorized (fast scalar path + `np.select` array path)
  - `compact_accretion`: scalar `np.clip(x,lo,hi)` → `min(max(...))` (removes 5.4M numpy-dispatch calls)
  - `evolution` / `hardening`: `np.append`-in-loop → list-accumulate + one `np.array` (O(N²) → O(N))
  - new `evolve_spin_during_accretion` — faster TDE spin integrator (math.sqrt, inlined BH branch, ISCO radius shared by E~/J~, final-state-only output), validated **bit-identical to the original `evolve()` over a 64-case oracle**; replaces it.

  ### Result
  E1: **~90 s → ~45 s (~2×)**. Heavy real clusters (N=15–22M) that took ~15 min or timed out now finish in **70–130 s**. No physics change.
